### PR TITLE
refactor(variables): adopt shorter component primitive naming

### DIFF
--- a/widget-src/components/checklist/WcagBadge.tsx
+++ b/widget-src/components/checklist/WcagBadge.tsx
@@ -1,5 +1,5 @@
 import { defaultTheme } from "design-system/theme/default";
-import { primitiveComponentVariables } from "design-system/components/primitives";
+import { componentPrimitives } from "design-system/components/primitives";
 import { buildWcagLinkSvg } from "ui/icons";
 import type { WCAGLevel } from "types";
 import { getWcagUrl } from "logic/wcag";
@@ -43,7 +43,7 @@ export function WcagBadge({
 }) {
   const wcagUrl = getWcagUrl(wcag);
   const badgeLabel = level ? `${wcag} (${level})` : wcag;
-  const badgeVariables = primitiveComponentVariables.wcagBadge;
+  const badgeVariables = componentPrimitives.wcagBadge;
   const resolvedIconColor =
     iconColor ?? textColor ?? defaultTheme.lightTheme.wcagBadgeText;
   const resolvedIconSize = iconSize ?? badgeVariables.iconSize;

--- a/widget-src/components/primitives/Checkbox.tsx
+++ b/widget-src/components/primitives/Checkbox.tsx
@@ -3,7 +3,7 @@ const { AutoLayout, SVG } = widget
 
 import { CheckboxProps } from "types/index";
 import { defaultTheme } from "design-system/theme/default";
-import { primitiveComponentVariables } from "design-system/components/primitives";
+import { componentPrimitives } from "design-system/components/primitives";
 import { buildCheckmarkSvg } from "ui/icons";
 
 /**
@@ -29,14 +29,14 @@ const Checkbox = ({ checked, colors, size, strokeWidth, radius }: CheckboxProps)
     colors?.bgUnchecked ?? defaultTheme.lightTheme.checkboxBgUnchecked;
   const strokeColor =
     colors?.stroke ?? defaultTheme.lightTheme.checkboxStroke;
-  const resolvedSize = size ?? primitiveComponentVariables.checkbox.size
+  const resolvedSize = size ?? componentPrimitives.checkbox.size
   const resolvedStrokeWidth =
-    strokeWidth ?? primitiveComponentVariables.checkbox.strokeWidth
-  const resolvedRadius = radius ?? primitiveComponentVariables.checkbox.radius
-  const checkmarkWidth = primitiveComponentVariables.checkbox.checkmark.width
-  const checkmarkHeight = primitiveComponentVariables.checkbox.checkmark.height
+    strokeWidth ?? componentPrimitives.checkbox.strokeWidth
+  const resolvedRadius = radius ?? componentPrimitives.checkbox.radius
+  const checkmarkWidth = componentPrimitives.checkbox.checkmark.width
+  const checkmarkHeight = componentPrimitives.checkbox.checkmark.height
   const checkmarkStrokeWidth =
-    primitiveComponentVariables.checkbox.checkmark.strokeWidth
+    componentPrimitives.checkbox.checkmark.strokeWidth
   const checkmarkColor =
     colors?.checkmark ?? defaultTheme.lightTheme.panelBg
   const checkmarkSvg = buildCheckmarkSvg({

--- a/widget-src/components/primitives/ProgressBar.tsx
+++ b/widget-src/components/primitives/ProgressBar.tsx
@@ -3,7 +3,7 @@ const { AutoLayout, Rectangle } = widget;
 
 import { ProgressBarProps } from "types/index";
 import { defaultTheme } from "design-system/theme/default";
-import { primitiveComponentVariables } from "design-system/components/primitives";
+import { componentPrimitives } from "design-system/components/primitives";
 
 /**
  * Renders a horizontal progress bar showing completion status for tasks.
@@ -50,9 +50,9 @@ const ProgressBar = ({
       direction="horizontal"
       overflow="hidden"
       width={parentWidth}
-      height={height ?? primitiveComponentVariables.progressBar.height}
+      height={height ?? componentPrimitives.progressBar.height}
       fill={colors?.track ?? defaultTheme.lightTheme.progressBg}
-      cornerRadius={radius ?? primitiveComponentVariables.progressBar.radius}
+      cornerRadius={radius ?? componentPrimitives.progressBar.radius}
       padding={0}
       spacing={0}
     >

--- a/widget-src/components/primitives/ProgressTracker.tsx
+++ b/widget-src/components/primitives/ProgressTracker.tsx
@@ -3,7 +3,7 @@ const { AutoLayout, Text } = widget;
 
 import { ProgressTrackerProps } from "types/index";
 import { defaultTheme } from "design-system/theme/default";
-import { primitiveComponentVariables } from "design-system/components/primitives";
+import { componentPrimitives } from "design-system/components/primitives";
 /**
  * Renders a pill-shaped progress tracker showing completed and total tasks.
  *
@@ -52,13 +52,13 @@ const ProgressTracker = ({
   return (
     <AutoLayout
       fill={fillColor}
-      cornerRadius={radius ?? primitiveComponentVariables.progressTracker.radius}
-      spacing={gap ?? primitiveComponentVariables.progressTracker.gap}
+      cornerRadius={radius ?? componentPrimitives.progressTracker.radius}
+      spacing={gap ?? componentPrimitives.progressTracker.gap}
       padding={{
         vertical:
-          padding?.vertical ?? primitiveComponentVariables.progressTracker.paddingY,
+          padding?.vertical ?? componentPrimitives.progressTracker.paddingY,
         horizontal:
-          padding?.horizontal ?? primitiveComponentVariables.progressTracker.paddingX,
+          padding?.horizontal ?? componentPrimitives.progressTracker.paddingX,
       }}
       horizontalAlignItems="center"
       verticalAlignItems="center"
@@ -69,11 +69,11 @@ const ProgressTracker = ({
         horizontalAlignText="right"
         lineHeight="140%"
         fontFamily={
-          fontFamily ?? primitiveComponentVariables.progressTracker.fontFamily
+          fontFamily ?? componentPrimitives.progressTracker.fontFamily
         }
-        fontSize={fontSize ?? primitiveComponentVariables.progressTracker.fontSize}
+        fontSize={fontSize ?? componentPrimitives.progressTracker.fontSize}
         fontWeight={
-          fontWeight ?? primitiveComponentVariables.progressTracker.fontWeight
+          fontWeight ?? componentPrimitives.progressTracker.fontWeight
         }
       >
         {completed} / {total}

--- a/widget-src/design-system/components/overlays.ts
+++ b/widget-src/design-system/components/overlays.ts
@@ -1,7 +1,7 @@
 import { gap, radius } from "../spacing";
 import { fontSize, fontWeight, fontFamily } from "../primitives/typography";
 import { borderWidth } from "../primitives/borders";
-import { primitiveComponentVariables } from "./primitives";
+import { componentPrimitives } from "./primitives";
 
 export type OverlayThemeVariables = {
   panelBg: string;
@@ -30,10 +30,10 @@ export function createOverlayVariables(theme: OverlayThemeVariables) {
       tight: gap.tight,
       outlineWidth: borderWidth.base,
       radius: radius.lg,
-      closeRadius: primitiveComponentVariables.overlayHeader.closeRadius,
+      closeRadius: componentPrimitives.overlayHeader.closeRadius,
       closePaddingX: gap.compact,
       closePaddingY: gap.tight,
-      headerSpacerHeight: primitiveComponentVariables.overlayHeader.spacerHeight,
+      headerSpacerHeight: componentPrimitives.overlayHeader.spacerHeight,
     },
     text: {
       title: {

--- a/widget-src/design-system/components/primitives.ts
+++ b/widget-src/design-system/components/primitives.ts
@@ -8,7 +8,7 @@ import { fontFamily, fontSize, fontWeight } from "../primitives/typography";
  * These values intentionally centralize defaults used by primitive components.
  * A few values are off-scale to preserve current visual output.
  */
-export const primitiveComponentVariables = {
+export const componentPrimitives = {
   checkbox: {
     size: 16,
     radius: 6,
@@ -52,13 +52,23 @@ export const primitiveComponentVariables = {
 } as const;
 
 /**
- * @deprecated Use `primitiveComponentVariables`.
+ * @deprecated Use `componentPrimitives`.
  */
-export const primitiveComponentTokens = primitiveComponentVariables;
-
-export type PrimitiveComponentVariables = typeof primitiveComponentVariables;
+export const primitiveComponentVariables = componentPrimitives;
 
 /**
- * @deprecated Use `PrimitiveComponentVariables`.
+ * @deprecated Use `componentPrimitives`.
  */
-export type PrimitiveComponentTokens = PrimitiveComponentVariables;
+export const primitiveComponentTokens = componentPrimitives;
+
+export type ComponentPrimitives = typeof componentPrimitives;
+
+/**
+ * @deprecated Use `ComponentPrimitives`.
+ */
+export type PrimitiveComponentVariables = ComponentPrimitives;
+
+/**
+ * @deprecated Use `ComponentPrimitives`.
+ */
+export type PrimitiveComponentTokens = ComponentPrimitives;

--- a/widget-src/design-system/index.ts
+++ b/widget-src/design-system/index.ts
@@ -61,8 +61,16 @@ export { createChecklistVariables, createChecklistTokens } from "./components/ch
 export type { ChecklistVariables, ChecklistTokens } from "./components/checklist";
 export { createOverlayVariables, createOverlayTokens } from "./components/overlays";
 export type { OverlayVariables, OverlayTokens } from "./components/overlays";
-export { primitiveComponentVariables, primitiveComponentTokens } from "./components/primitives";
-export type { PrimitiveComponentVariables, PrimitiveComponentTokens } from "./components/primitives";
+export {
+  componentPrimitives,
+  primitiveComponentVariables,
+  primitiveComponentTokens,
+} from "./components/primitives";
+export type {
+  ComponentPrimitives,
+  PrimitiveComponentVariables,
+  PrimitiveComponentTokens,
+} from "./components/primitives";
 
 // Import primitives for bundled export
 import {


### PR DESCRIPTION
- introduce canonical  export for primitive component variables
- migrate primitive and checklist components to the new naming for readability
- preserve deprecated aliases ( and related types) for compatibility
