### PR TITLE
docs(policy): lock deterministic accent step contract for phase 2

### DIFF
--- a/scripts/test-hardening.mjs
+++ b/scripts/test-hardening.mjs
@@ -13,7 +13,12 @@ async function runHardeningChecks() {
   const entry = `
     import assert from "node:assert/strict";
     import { normalizeHexColor } from "./widget-src/shared/hexColor";
-    import { inferThemePresetFromAccent } from "./widget-src/theme/index";
+    import {
+      inferThemePresetFromAccent,
+      resolveTheme,
+      themePresets,
+    } from "./widget-src/theme/index";
+    import { accentStepPolicy } from "./widget-src/design-system/theme/contrastPolicy";
     import {
       capAvatarIds,
       resolveAvatarStep,
@@ -43,6 +48,65 @@ async function runHardeningChecks() {
     assert.equal(resolveAvatarStackWidth(0, 34, 26), 0);
     assert.equal(resolveAvatarStackWidth(1, 34, 26), 34);
     assert.equal(resolveAvatarStackWidth(5, 34, 26), 138);
+
+    assert.equal(accentStepPolicy.stepSize, 100);
+    assert.equal(accentStepPolicy.mode.light.primaryDirection, "darker");
+    assert.equal(accentStepPolicy.mode.light.fallbackDirection, "lighter");
+    assert.equal(accentStepPolicy.mode.dark.primaryDirection, "lighter");
+    assert.equal(accentStepPolicy.mode.dark.fallbackDirection, "darker");
+    assert.equal(accentStepPolicy.stopCondition, "first-pass");
+    assert.equal(
+      accentStepPolicy.unresolvedBehavior,
+      "fail-validation-no-silent-mutation"
+    );
+    assert.equal(accentStepPolicy.thresholds.normalTextAA, 4.5);
+    assert.equal(accentStepPolicy.thresholds.largeTextAA, 3.0);
+
+    const presetNames = Object.keys(themePresets);
+    for (const preset of presetNames) {
+      const tokens = resolveTheme(true, preset);
+      assert.equal(
+        tokens.progressFill,
+        themePresets[preset].darkTheme.progressFill,
+        "Dark theme base resolution should match preset dark progressFill.",
+      );
+    }
+
+    const presetSwatchMatrix = [
+      { swatch: "#4E56A0", expectedPreset: "default" },
+      { swatch: "#4F46E5", expectedPreset: "indigo" },
+      { swatch: "#059669", expectedPreset: "emerald" },
+      { swatch: "#E11D48", expectedPreset: "rose" },
+      { swatch: "#475569", expectedPreset: "slate" },
+      { swatch: "#0891B2", expectedPreset: "cyan" },
+    ];
+
+    for (const row of presetSwatchMatrix) {
+      const matched = inferThemePresetFromAccent(row.swatch);
+      assert.equal(matched, row.expectedPreset);
+      const preset = matched ?? "default";
+      const accentOverride = matched ? undefined : row.swatch;
+      const dark = resolveTheme(true, preset, accentOverride);
+      assert.equal(
+        dark.progressFill,
+        themePresets[row.expectedPreset].darkTheme.progressFill,
+        "Preset swatches should resolve via preset dark accent, not raw override."
+      );
+    }
+
+    const customAccent = "#123456";
+    const matchedCustom = inferThemePresetFromAccent(customAccent);
+    assert.equal(matchedCustom, undefined);
+    const customDark = resolveTheme(
+      true,
+      matchedCustom ?? "default",
+      matchedCustom ? undefined : customAccent
+    );
+    assert.equal(
+      customDark.progressFill,
+      customAccent,
+      "Unknown custom accent should remain a direct override until step-policy runtime is enabled."
+    );
 
     console.log("Hardening checks passed.");
   `;
@@ -85,4 +149,3 @@ runHardeningChecks().catch((error) => {
   console.error(error.message || error);
   process.exit(1);
 });
-

--- a/widget-src/design-system/theme/contrastPolicy.ts
+++ b/widget-src/design-system/theme/contrastPolicy.ts
@@ -1,0 +1,45 @@
+export type AccentStepDirection = "lighter" | "darker";
+export type ContrastMode = "light" | "dark";
+
+export interface AccentStepPolicyMode {
+  primaryDirection: AccentStepDirection;
+  fallbackDirection: AccentStepDirection;
+}
+
+export interface AccentStepPolicy {
+  stepSize: 100;
+  mode: Record<ContrastMode, AccentStepPolicyMode>;
+  stopCondition: "first-pass";
+  unresolvedBehavior: "fail-validation-no-silent-mutation";
+  thresholds: {
+    normalTextAA: 4.5;
+    largeTextAA: 3.0;
+  };
+}
+
+/**
+ * Phase 2 deterministic accent-step policy.
+ *
+ * This policy describes how runtime accent fallback should behave when an accent
+ * fails required contrast checks. Runtime integration is implemented separately.
+ */
+export const accentStepPolicy: AccentStepPolicy = {
+  stepSize: 100,
+  mode: {
+    light: {
+      primaryDirection: "darker",
+      fallbackDirection: "lighter",
+    },
+    dark: {
+      primaryDirection: "lighter",
+      fallbackDirection: "darker",
+    },
+  },
+  stopCondition: "first-pass",
+  unresolvedBehavior: "fail-validation-no-silent-mutation",
+  thresholds: {
+    normalTextAA: 4.5,
+    largeTextAA: 3.0,
+  },
+} as const;
+


### PR DESCRIPTION
- add tracked accent step policy module with mode directions, thresholds, stop condition, and unresolved behavior

- extend hardening tests with accent policy assertions and preset swatch runtime matrix

- keep runtime behavior unchanged in this PR to isolate policy and test baseline
