### PR TITLE
feat(theme): apply deterministic contrast-safe accent resolution

### DIFF
--- a/scripts/test-hardening.mjs
+++ b/scripts/test-hardening.mjs
@@ -13,7 +13,13 @@ async function runHardeningChecks() {
   const entry = `
     import assert from "node:assert/strict";
     import { normalizeHexColor } from "./widget-src/shared/hexColor";
-    import { inferThemePresetFromAccent } from "./widget-src/theme/index";
+    import {
+      inferThemePresetFromAccent,
+      resolveTheme,
+      themePresets,
+    } from "./widget-src/theme/index";
+    import { accentStepPolicy } from "./widget-src/design-system/theme/contrastPolicy";
+    import { calculateContrastRatioHex } from "./widget-src/design-system/utils/contrast";
     import {
       capAvatarIds,
       resolveAvatarStep,
@@ -43,6 +49,74 @@ async function runHardeningChecks() {
     assert.equal(resolveAvatarStackWidth(0, 34, 26), 0);
     assert.equal(resolveAvatarStackWidth(1, 34, 26), 34);
     assert.equal(resolveAvatarStackWidth(5, 34, 26), 138);
+
+    assert.equal(accentStepPolicy.stepSize, 100);
+    assert.equal(accentStepPolicy.mode.light.primaryDirection, "darker");
+    assert.equal(accentStepPolicy.mode.light.fallbackDirection, "lighter");
+    assert.equal(accentStepPolicy.mode.dark.primaryDirection, "lighter");
+    assert.equal(accentStepPolicy.mode.dark.fallbackDirection, "darker");
+    assert.equal(accentStepPolicy.stopCondition, "first-pass");
+    assert.equal(
+      accentStepPolicy.unresolvedBehavior,
+      "fail-validation-no-silent-mutation"
+    );
+    assert.equal(accentStepPolicy.thresholds.normalTextAA, 4.5);
+    assert.equal(accentStepPolicy.thresholds.largeTextAA, 3.0);
+
+    const presetNames = Object.keys(themePresets);
+    for (const preset of presetNames) {
+      const light = resolveTheme(false, preset);
+      const dark = resolveTheme(true, preset);
+      const lightRatio = calculateContrastRatioHex(light.progressFill, light.panelBg);
+      const darkRatio = calculateContrastRatioHex(dark.progressFill, dark.panelBg);
+      assert.ok(
+        typeof lightRatio === "number" && lightRatio >= 4.5,
+        "Light mode progressFill should pass AA after runtime policy resolution."
+      );
+      assert.ok(
+        typeof darkRatio === "number" && darkRatio >= 4.5,
+        "Dark mode progressFill should pass AA after runtime policy resolution."
+      );
+    }
+
+    const presetSwatchMatrix = [
+      { swatch: "#4E56A0", expectedPreset: "default" },
+      { swatch: "#4F46E5", expectedPreset: "indigo" },
+      { swatch: "#059669", expectedPreset: "emerald" },
+      { swatch: "#E11D48", expectedPreset: "rose" },
+      { swatch: "#475569", expectedPreset: "slate" },
+      { swatch: "#0891B2", expectedPreset: "cyan" },
+    ];
+
+    for (const row of presetSwatchMatrix) {
+      const matched = inferThemePresetFromAccent(row.swatch);
+      assert.equal(matched, row.expectedPreset);
+      const preset = matched ?? "default";
+      const accentOverride = matched ? undefined : row.swatch;
+      const dark = resolveTheme(true, preset, accentOverride);
+      const darkRatio = calculateContrastRatioHex(dark.progressFill, dark.panelBg);
+      assert.ok(
+        typeof darkRatio === "number" && darkRatio >= 4.5,
+        "Resolved dark preset swatch accent should pass AA."
+      );
+    }
+
+    const customAccent = "#123456";
+    const matchedCustom = inferThemePresetFromAccent(customAccent);
+    assert.equal(matchedCustom, undefined);
+    const customDark = resolveTheme(
+      true,
+      matchedCustom ?? "default",
+      matchedCustom ? undefined : customAccent
+    );
+    const customDarkRatio = calculateContrastRatioHex(
+      customDark.progressFill,
+      customDark.panelBg
+    );
+    assert.ok(
+      typeof customDarkRatio === "number" && customDarkRatio >= 4.5,
+      "Custom dark accent should resolve to a contrast-safe value."
+    );
 
     console.log("Hardening checks passed.");
   `;
@@ -85,4 +159,3 @@ runHardeningChecks().catch((error) => {
   console.error(error.message || error);
   process.exit(1);
 });
-

--- a/scripts/test-hardening.mjs
+++ b/scripts/test-hardening.mjs
@@ -67,15 +67,34 @@ async function runHardeningChecks() {
     for (const preset of presetNames) {
       const light = resolveTheme(false, preset);
       const dark = resolveTheme(true, preset);
-      const lightRatio = calculateContrastRatioHex(light.progressFill, light.panelBg);
-      const darkRatio = calculateContrastRatioHex(dark.progressFill, dark.panelBg);
+      const lightPanelRatio = calculateContrastRatioHex(
+        light.progressFill,
+        light.panelBg
+      );
+      const lightHeaderRatio = calculateContrastRatioHex(
+        light.progressFill,
+        light.headerBg
+      );
+      const darkPanelRatio = calculateContrastRatioHex(dark.progressFill, dark.panelBg);
+      const darkHeaderRatio = calculateContrastRatioHex(
+        dark.progressFill,
+        dark.headerBg
+      );
       assert.ok(
-        typeof lightRatio === "number" && lightRatio >= 4.5,
+        typeof lightPanelRatio === "number" && lightPanelRatio >= 4.5,
         "Light mode progressFill should pass AA after runtime policy resolution."
       );
       assert.ok(
-        typeof darkRatio === "number" && darkRatio >= 4.5,
+        typeof lightHeaderRatio === "number" && lightHeaderRatio >= 4.5,
+        "Light mode progressFill should pass AA against header backgrounds."
+      );
+      assert.ok(
+        typeof darkPanelRatio === "number" && darkPanelRatio >= 4.5,
         "Dark mode progressFill should pass AA after runtime policy resolution."
+      );
+      assert.ok(
+        typeof darkHeaderRatio === "number" && darkHeaderRatio >= 4.5,
+        "Dark mode progressFill should pass AA against header backgrounds."
       );
     }
 
@@ -91,13 +110,22 @@ async function runHardeningChecks() {
     for (const row of presetSwatchMatrix) {
       const matched = inferThemePresetFromAccent(row.swatch);
       assert.equal(matched, row.expectedPreset);
-      const preset = matched ?? "default";
-      const accentOverride = matched ? undefined : row.swatch;
-      const dark = resolveTheme(true, preset, accentOverride);
-      const darkRatio = calculateContrastRatioHex(dark.progressFill, dark.panelBg);
+      const dark = resolveTheme(true, "default", row.swatch);
+      const darkPanelRatio = calculateContrastRatioHex(
+        dark.progressFill,
+        dark.panelBg
+      );
+      const darkHeaderRatio = calculateContrastRatioHex(
+        dark.progressFill,
+        dark.headerBg
+      );
       assert.ok(
-        typeof darkRatio === "number" && darkRatio >= 4.5,
-        "Resolved dark preset swatch accent should pass AA."
+        typeof darkPanelRatio === "number" && darkPanelRatio >= 4.5,
+        "Resolved dark override swatch accent should pass AA."
+      );
+      assert.ok(
+        typeof darkHeaderRatio === "number" && darkHeaderRatio >= 4.5,
+        "Resolved dark override swatch accent should pass AA against header backgrounds."
       );
     }
 
@@ -113,9 +141,17 @@ async function runHardeningChecks() {
       customDark.progressFill,
       customDark.panelBg
     );
+    const customDarkHeaderRatio = calculateContrastRatioHex(
+      customDark.progressFill,
+      customDark.headerBg
+    );
     assert.ok(
       typeof customDarkRatio === "number" && customDarkRatio >= 4.5,
       "Custom dark accent should resolve to a contrast-safe value."
+    );
+    assert.ok(
+      typeof customDarkHeaderRatio === "number" && customDarkHeaderRatio >= 4.5,
+      "Custom dark accent should be contrast-safe on header backgrounds."
     );
 
     console.log("Hardening checks passed.");

--- a/widget-src/design-system/theme/contrastPolicy.ts
+++ b/widget-src/design-system/theme/contrastPolicy.ts
@@ -213,7 +213,7 @@ export function resolveContrastSafeAccent(
           : candidateIndex === referenceIndex
             ? "mapped"
             : "stepped",
-      shadeStep: candidate.shade - referenceShade,
+      shadeStep: candidateIndex - referenceIndex,
     };
   }
 

--- a/widget-src/design-system/theme/contrastPolicy.ts
+++ b/widget-src/design-system/theme/contrastPolicy.ts
@@ -1,0 +1,213 @@
+import { calculateContrastRatioHex, WCAG_AA } from "../utils/contrast";
+import type { ThemeConfig } from "./types";
+import { normalizeHexColor } from "shared/hexColor";
+
+export type AccentStepDirection = "lighter" | "darker";
+export type ContrastMode = "light" | "dark";
+
+export interface AccentStepPolicyMode {
+  primaryDirection: AccentStepDirection;
+  fallbackDirection: AccentStepDirection;
+}
+
+export interface AccentStepPolicy {
+  stepSize: 100;
+  mode: Record<ContrastMode, AccentStepPolicyMode>;
+  stopCondition: "first-pass";
+  unresolvedBehavior: "fail-validation-no-silent-mutation";
+  thresholds: {
+    normalTextAA: 4.5;
+    largeTextAA: 3.0;
+  };
+}
+
+export interface ResolvedAccentResult {
+  accent: string;
+  source: "input" | "stepped" | "unresolved";
+  shadeStep: number;
+}
+
+interface BrandScaleEntry {
+  shade: number;
+  color: string;
+}
+
+const policyDirectionOffset: Record<AccentStepDirection, number> = {
+  lighter: -1,
+  darker: 1,
+};
+
+/**
+ * Phase 2 deterministic accent-step policy.
+ */
+export const accentStepPolicy: AccentStepPolicy = {
+  stepSize: 100,
+  mode: {
+    light: {
+      primaryDirection: "darker",
+      fallbackDirection: "lighter",
+    },
+    dark: {
+      primaryDirection: "lighter",
+      fallbackDirection: "darker",
+    },
+  },
+  stopCondition: "first-pass",
+  unresolvedBehavior: "fail-validation-no-silent-mutation",
+  thresholds: {
+    normalTextAA: 4.5,
+    largeTextAA: 3.0,
+  },
+} as const;
+
+function buildBrandScale(theme: ThemeConfig): BrandScaleEntry[] {
+  return Object.entries(theme.brand.purple)
+    .map(([shade, color]) => {
+      const normalizedColor = normalizeHexColor(String(color));
+      return {
+        shade: Number(shade),
+        color: normalizedColor ?? String(color),
+      };
+    })
+    .filter((entry) => Number.isFinite(entry.shade))
+    .sort((left, right) => left.shade - right.shade);
+}
+
+function parseHexRgb(hex: string): [number, number, number] {
+  return [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16),
+  ];
+}
+
+function colorDistance(hexA: string, hexB: string): number {
+  const [ar, ag, ab] = parseHexRgb(hexA);
+  const [br, bg, bb] = parseHexRgb(hexB);
+  return Math.sqrt(
+    (ar - br) * (ar - br) +
+      (ag - bg) * (ag - bg) +
+      (ab - bb) * (ab - bb)
+  );
+}
+
+function findNearestScaleIndex(scale: BrandScaleEntry[], accent: string): number {
+  const exactIndex = scale.findIndex((entry) => entry.color === accent);
+  if (exactIndex >= 0) return exactIndex;
+
+  let bestIndex = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < scale.length; index += 1) {
+    const distance = colorDistance(accent, scale[index].color);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  }
+  return bestIndex;
+}
+
+function buildCandidateIndices(
+  referenceIndex: number,
+  scaleLength: number,
+  mode: ContrastMode
+): number[] {
+  const result: number[] = [];
+  const modePolicy = accentStepPolicy.mode[mode];
+  const primaryOffset = policyDirectionOffset[modePolicy.primaryDirection];
+  const fallbackOffset = policyDirectionOffset[modePolicy.fallbackDirection];
+
+  const pushIndex = (index: number) => {
+    if (index < 0 || index >= scaleLength) return;
+    if (result.includes(index)) return;
+    result.push(index);
+  };
+
+  pushIndex(referenceIndex);
+
+  for (let delta = 1; delta < scaleLength; delta += 1) {
+    pushIndex(referenceIndex + primaryOffset * delta);
+  }
+
+  for (let delta = 1; delta < scaleLength; delta += 1) {
+    pushIndex(referenceIndex + fallbackOffset * delta);
+  }
+
+  return result;
+}
+
+function passesRequiredContrast(accent: string, backgrounds: string[]): boolean {
+  const threshold = WCAG_AA.normal;
+  for (const background of backgrounds) {
+    const ratio = calculateContrastRatioHex(accent, background);
+    if (typeof ratio !== "number" || ratio < threshold) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Resolve an accent color using deterministic stepping rules so runtime values
+ * can meet required text contrast thresholds.
+ */
+export function resolveContrastSafeAccent(
+  accent: string,
+  mode: ContrastMode,
+  theme: ThemeConfig,
+  backgrounds: string[]
+): ResolvedAccentResult {
+  const normalizedAccent = normalizeHexColor(accent);
+  const normalizedBackgrounds = backgrounds
+    .map((value) => normalizeHexColor(value))
+    .filter((value): value is string => Boolean(value));
+
+  if (!normalizedAccent || normalizedBackgrounds.length === 0) {
+    return {
+      accent,
+      source: "unresolved",
+      shadeStep: 0,
+    };
+  }
+
+  if (passesRequiredContrast(normalizedAccent, normalizedBackgrounds)) {
+    return {
+      accent: normalizedAccent,
+      source: "input",
+      shadeStep: 0,
+    };
+  }
+
+  const scale = buildBrandScale(theme);
+  if (scale.length === 0) {
+    return {
+      accent: normalizedAccent,
+      source: "unresolved",
+      shadeStep: 0,
+    };
+  }
+
+  const referenceIndex = findNearestScaleIndex(scale, normalizedAccent);
+  const referenceShade = scale[referenceIndex].shade;
+  const candidateIndices = buildCandidateIndices(referenceIndex, scale.length, mode);
+
+  for (const candidateIndex of candidateIndices) {
+    const candidate = scale[candidateIndex];
+    if (!passesRequiredContrast(candidate.color, normalizedBackgrounds)) {
+      continue;
+    }
+
+    return {
+      accent: candidate.color,
+      source: candidate.color === normalizedAccent ? "input" : "stepped",
+      shadeStep: candidate.shade - referenceShade,
+    };
+  }
+
+  return {
+    accent: normalizedAccent,
+    source: "unresolved",
+    shadeStep: 0,
+  };
+}
+

--- a/widget-src/design-system/theme/contrastPolicy.ts
+++ b/widget-src/design-system/theme/contrastPolicy.ts
@@ -1,4 +1,4 @@
-import { calculateContrastRatioHex, WCAG_AA } from "../utils/contrast";
+import { calculateContrastRatioHex } from "../utils/contrast";
 import type { ThemeConfig } from "./types";
 import { normalizeHexColor } from "shared/hexColor";
 
@@ -6,24 +6,24 @@ export type AccentStepDirection = "lighter" | "darker";
 export type ContrastMode = "light" | "dark";
 
 export interface AccentStepPolicyMode {
-  primaryDirection: AccentStepDirection;
-  fallbackDirection: AccentStepDirection;
+  readonly primaryDirection: AccentStepDirection;
+  readonly fallbackDirection: AccentStepDirection;
 }
 
 export interface AccentStepPolicy {
-  stepSize: 100;
-  mode: Record<ContrastMode, AccentStepPolicyMode>;
-  stopCondition: "first-pass";
-  unresolvedBehavior: "fail-validation-no-silent-mutation";
-  thresholds: {
-    normalTextAA: 4.5;
-    largeTextAA: 3.0;
+  readonly stepSize: number;
+  readonly mode: Record<ContrastMode, AccentStepPolicyMode>;
+  readonly stopCondition: "first-pass";
+  readonly unresolvedBehavior: "fail-validation-no-silent-mutation";
+  readonly thresholds: {
+    readonly normalTextAA: number;
+    readonly largeTextAA: number;
   };
 }
 
 export interface ResolvedAccentResult {
   accent: string;
-  source: "input" | "stepped" | "unresolved";
+  source: "input" | "mapped" | "stepped" | "unresolved";
   shadeStep: number;
 }
 
@@ -40,7 +40,7 @@ const policyDirectionOffset: Record<AccentStepDirection, number> = {
 /**
  * Phase 2 deterministic accent-step policy.
  */
-export const accentStepPolicy: AccentStepPolicy = {
+export const accentStepPolicy = {
   stepSize: 100,
   mode: {
     light: {
@@ -58,18 +58,26 @@ export const accentStepPolicy: AccentStepPolicy = {
     normalTextAA: 4.5,
     largeTextAA: 3.0,
   },
-} as const;
+} as const satisfies AccentStepPolicy;
 
 function buildBrandScale(theme: ThemeConfig): BrandScaleEntry[] {
   return Object.entries(theme.brand.purple)
     .map(([shade, color]) => {
       const normalizedColor = normalizeHexColor(String(color));
+      if (!normalizedColor) {
+        return null;
+      }
       return {
         shade: Number(shade),
-        color: normalizedColor ?? String(color),
+        color: normalizedColor,
       };
     })
-    .filter((entry) => Number.isFinite(entry.shade))
+    .filter(
+      (entry): entry is BrandScaleEntry => {
+        if (!entry) return false;
+        return Number.isFinite(entry.shade);
+      }
+    )
     .sort((left, right) => left.shade - right.shade);
 }
 
@@ -137,7 +145,7 @@ function buildCandidateIndices(
 }
 
 function passesRequiredContrast(accent: string, backgrounds: string[]): boolean {
-  const threshold = WCAG_AA.normal;
+  const threshold = accentStepPolicy.thresholds.normalTextAA;
   for (const background of backgrounds) {
     const ratio = calculateContrastRatioHex(accent, background);
     if (typeof ratio !== "number" || ratio < threshold) {
@@ -199,7 +207,12 @@ export function resolveContrastSafeAccent(
 
     return {
       accent: candidate.color,
-      source: candidate.color === normalizedAccent ? "input" : "stepped",
+      source:
+        candidate.color === normalizedAccent
+          ? "input"
+          : candidateIndex === referenceIndex
+            ? "mapped"
+            : "stepped",
       shadeStep: candidate.shade - referenceShade,
     };
   }
@@ -210,4 +223,3 @@ export function resolveContrastSafeAccent(
     shadeStep: 0,
   };
 }
-

--- a/widget-src/theme/index.ts
+++ b/widget-src/theme/index.ts
@@ -1,4 +1,5 @@
 import { defaultTheme, themePresets, type ThemePresetName } from "design-system";
+import { resolveContrastSafeAccent } from "design-system/theme/contrastPolicy";
 import { normalizeHexColor } from "shared/hexColor";
 
 export type ThemeName = "light" | "dark";
@@ -73,11 +74,18 @@ export function resolveTheme(
   const theme = themePresets[preset] ?? defaultTheme;
   const base = (isDark ? theme.darkTheme : theme.lightTheme) as ThemeTokens;
   const normalizedAccent = normalizeHexColor(accentColor);
-  if (!normalizedAccent) return base;
+  const requestedAccent = normalizedAccent ?? normalizeHexColor(base.progressFill);
+  if (!requestedAccent) return base;
+  const mode = isDark ? "dark" : "light";
+  const resolvedAccent = resolveContrastSafeAccent(requestedAccent, mode, theme, [
+    base.panelBg,
+    base.headerBg,
+  ]);
+
   return {
     ...base,
-    progressFill: normalizedAccent,
-    checkboxBgChecked: normalizedAccent,
-    checkboxStroke: normalizedAccent,
+    progressFill: resolvedAccent.accent,
+    checkboxBgChecked: resolvedAccent.accent,
+    checkboxStroke: resolvedAccent.accent,
   };
 }


### PR DESCRIPTION
- add phase 2 accent contrast policy module and deterministic shade stepping helpers

- enforce contrast-safe accent resolution in resolveTheme for base and override accents

- keep unresolved policy explicit with no silent mutation beyond deterministic step attempts

- expand hardening tests to verify AA pass across presets and custom dark accents
