### PR TITLE
feat(wcag): add generated map validation gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "watch:ds:strict": "node scripts/watch-design-system.mjs --with-contrast-aa",
     "sync:a11y-checklist": "node scripts/sync-a11y-checklist.mjs",
     "generate:wcag-level-map": "node scripts/generate-wcag-level-map.mjs",
+    "validate:wcag-map": "node scripts/validate-wcag-level-map.mjs",
     "test:hardening": "node scripts/test-hardening.mjs",
     "check:safe": "pnpm run build && pnpm run tsc && pnpm run lint && pnpm run test:hardening",
     "tsc": "tsc --noEmit -p widget-src",

--- a/scripts/sync-a11y-checklist.mjs
+++ b/scripts/sync-a11y-checklist.mjs
@@ -67,6 +67,21 @@ async function main() {
       `WCAG level map generation failed with exit code ${generateMap.status ?? "unknown"}.`,
     );
   }
+
+  const validateMap = spawnSync(
+    process.execPath,
+    [path.resolve(__dirname, "./validate-wcag-level-map.mjs")],
+    {
+      cwd: path.resolve(__dirname, ".."),
+      stdio: "inherit",
+    },
+  );
+
+  if (validateMap.status !== 0) {
+    throw new Error(
+      `WCAG level map validation failed with exit code ${validateMap.status ?? "unknown"}.`,
+    );
+  }
 }
 
 main().catch((err) => {

--- a/scripts/validate-wcag-level-map.mjs
+++ b/scripts/validate-wcag-level-map.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import { build } from "esbuild";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+
+const ROOT = process.cwd();
+
+function compact(value) {
+  return JSON.stringify(value).replace(/<\\\//g, "</");
+}
+
+async function validateWcagMap() {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "a11y-wcag-map-"));
+  const bundlePath = path.join(tempDir, "validate-wcag-map.bundle.cjs");
+
+  const entry = `
+    import {
+      wcagLevelCriteriaMap,
+      wcagCriteriaByLevel,
+    } from "./widget-src/data/wcagLevelMap";
+
+    const LEVELS = ${compact(["A", "AA", "AAA"])};
+    const codeRegex = /^\\d+\\.\\d+\\.\\d+$/;
+    const errors = [];
+    const summary = {
+      totalCriteria: 0,
+      byLevel: {},
+    };
+
+    for (const level of LEVELS) {
+      const criteria = wcagLevelCriteriaMap[level];
+      const codeList = wcagCriteriaByLevel[level];
+
+      if (!Array.isArray(criteria)) {
+        errors.push(\`Missing criteria array for level \${level}.\`);
+        continue;
+      }
+      if (!Array.isArray(codeList)) {
+        errors.push(\`Missing code array for level \${level}.\`);
+      }
+      if (criteria.length === 0) {
+        errors.push(\`No criteria entries found for level \${level}.\`);
+      }
+
+      const seenCodes = new Set();
+      for (const [index, entry] of criteria.entries()) {
+        const context = \`\${level}[\\\${index}]\`;
+        const code = String(entry?.code ?? "").trim();
+        const title = String(entry?.title ?? "").trim();
+        const url = String(entry?.url ?? "").trim();
+
+        if (!codeRegex.test(code)) {
+          errors.push(\`\${context}: malformed criterion code "\${code}".\`);
+        }
+        if (!title) {
+          errors.push(\`\${context}: missing criterion title.\`);
+        }
+        if (!url) {
+          errors.push(\`\${context}: missing criterion URL.\`);
+        }
+        if (seenCodes.has(code)) {
+          errors.push(\`\${context}: duplicate criterion code "\${code}" within level \${level}.\`);
+        }
+        seenCodes.add(code);
+      }
+
+      if (Array.isArray(codeList)) {
+        const criteriaCodes = criteria.map((entry) => entry.code);
+        const criteriaSet = new Set(criteriaCodes);
+        const codeListSet = new Set(codeList);
+
+        for (const code of codeList) {
+          if (!criteriaSet.has(code)) {
+            errors.push(
+              \`wcagCriteriaByLevel[\${level}] includes code "\${code}" missing from wcagLevelCriteriaMap.\`
+            );
+          }
+        }
+
+        for (const code of criteriaCodes) {
+          if (!codeListSet.has(code)) {
+            errors.push(
+              \`wcagLevelCriteriaMap[\${level}] code "\${code}" missing from wcagCriteriaByLevel.\`
+            );
+          }
+        }
+      }
+
+      summary.byLevel[level] = criteria.length;
+      summary.totalCriteria += criteria.length;
+    }
+
+    const crossLevel = new Map();
+    for (const level of LEVELS) {
+      const criteria = Array.isArray(wcagLevelCriteriaMap[level])
+        ? wcagLevelCriteriaMap[level]
+        : [];
+      for (const entry of criteria) {
+        const code = String(entry?.code ?? "").trim();
+        if (!code) continue;
+        const levels = crossLevel.get(code) ?? new Set();
+        levels.add(level);
+        crossLevel.set(code, levels);
+      }
+    }
+
+    for (const [code, levels] of crossLevel.entries()) {
+      if (levels.size > 1) {
+        errors.push(
+          \`Criterion code "\${code}" appears in multiple levels: \${[...levels].sort().join(", ")}.\`
+        );
+      }
+    }
+
+    console.log(JSON.stringify({ summary, errors }));
+  `;
+
+  try {
+    await build({
+      stdin: {
+        contents: entry,
+        resolveDir: ROOT,
+        sourcefile: "validate-wcag-map-entry.ts",
+        loader: "ts",
+      },
+      bundle: true,
+      platform: "node",
+      format: "cjs",
+      target: "node18",
+      outfile: bundlePath,
+      logLevel: "silent",
+    });
+
+    const run = spawnSync(process.execPath, [bundlePath], {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+
+    if (run.status !== 0) {
+      throw new Error(`WCAG map validation runner failed.\n${run.stderr || ""}`);
+    }
+
+    const stdout = (run.stdout || "").trim();
+    if (!stdout) {
+      throw new Error("WCAG map validation produced no output.");
+    }
+
+    return JSON.parse(stdout);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const report = await validateWcagMap();
+  const levels = Object.entries(report.summary.byLevel)
+    .map(([level, count]) => `${level}:${count}`)
+    .join(", ");
+
+  console.log(
+    `WCAG map validation scanned ${report.summary.totalCriteria} criteria (${levels}).`
+  );
+
+  if (report.errors.length === 0) {
+    console.log("WCAG map validation passed.");
+    return;
+  }
+
+  console.error(`WCAG map validation failed with ${report.errors.length} issue(s):`);
+  report.errors.forEach((error) => {
+    console.error(`- ${error}`);
+  });
+  process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});
+

--- a/scripts/validate-wcag-level-map.mjs
+++ b/scripts/validate-wcag-level-map.mjs
@@ -47,7 +47,7 @@ async function validateWcagMap() {
 
       const seenCodes = new Set();
       for (const [index, entry] of criteria.entries()) {
-        const context = \`\${level}[\\\${index}]\`;
+        const context = \`\${level}[\${index}]\`;
         const code = String(entry?.code ?? "").trim();
         const title = String(entry?.title ?? "").trim();
         const url = String(entry?.url ?? "").trim();
@@ -68,11 +68,16 @@ async function validateWcagMap() {
       }
 
       if (Array.isArray(codeList)) {
-        const criteriaCodes = criteria.map((entry) => entry.code);
+        const criteriaCodes = criteria.map((entry) =>
+          String(entry?.code ?? "").trim()
+        );
+        const normalizedCodeList = codeList.map((code) =>
+          String(code ?? "").trim()
+        );
         const criteriaSet = new Set(criteriaCodes);
-        const codeListSet = new Set(codeList);
+        const codeListSet = new Set(normalizedCodeList);
 
-        for (const code of codeList) {
+        for (const code of normalizedCodeList) {
           if (!criteriaSet.has(code)) {
             errors.push(
               \`wcagCriteriaByLevel[\${level}] includes code "\${code}" missing from wcagLevelCriteriaMap.\`
@@ -139,6 +144,14 @@ async function validateWcagMap() {
       encoding: "utf8",
     });
 
+    if (run.error) {
+      throw new Error(
+        `WCAG map validation runner failed to spawn.\n${String(
+          run.error.message || run.error
+        )}`
+      );
+    }
+
     if (run.status !== 0) {
       throw new Error(`WCAG map validation runner failed.\n${run.stderr || ""}`);
     }
@@ -180,4 +193,3 @@ main().catch((error) => {
   console.error(error.message || error);
   process.exit(1);
 });
-


### PR DESCRIPTION
- add validate-wcag-level-map script to verify generated map structure and metadata integrity

- detect malformed criterion codes, missing fields, duplicate codes per level, and cross-level collisions

- wire sync-a11y-checklist to run map validation after generation

- add pnpm script validate:wcag-map for local and CI checks
