### PR TITLE
chore(ci): add auto-assignment workflow for issues and PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,48 @@
+name: Auto Assign Author
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign to author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isPR = !!context.payload.pull_request;
+            const item = isPR ? context.payload.pull_request : context.payload.issue;
+            const number = item.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const assignee = item.user.login;
+            const alreadyAssigned = (item.assignees || []).some(
+              (existing) => existing.login === assignee
+            );
+
+            if (alreadyAssigned) {
+              console.log(`${assignee} is already assigned to #${number}.`);
+              return;
+            }
+
+            try {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: number,
+                assignees: [assignee],
+              });
+              console.log(`Assigned ${assignee} to #${number}.`);
+            } catch (error) {
+              console.log(
+                `Skipping assignment for #${number}: ${error.message || String(error)}`
+              );
+            }


### PR DESCRIPTION
- add GitHub Actions workflow to auto-assign issue and pull request authors

- resolve assignee from payload user to match the author consistently

- skip duplicate assignment attempts and log non-fatal assignment failures
