### PR TITLE
feat(widget): ship phase 4 contrast inspector and ux upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,9 @@ assets
 # build
 /dist
 
-# planning
+# ai/planning
 .claude
+.codex
 
 # markdown
 *.md

--- a/scripts/test-hardening.mjs
+++ b/scripts/test-hardening.mjs
@@ -25,6 +25,8 @@ async function runHardeningChecks() {
       resolveAvatarStep,
       resolveAvatarStackWidth,
     } from "./widget-src/shared/avatarStack";
+    import { getContrastNotice } from "./widget-src/shared/contrastMessages";
+    import { resolvePreferenceNamespace } from "./widget-src/shared/preferenceNamespace";
 
     assert.equal(normalizeHexColor("#abc"), "#AABBCC");
     assert.equal(normalizeHexColor("#a1b2c3"), "#A1B2C3");
@@ -49,6 +51,44 @@ async function runHardeningChecks() {
     assert.equal(resolveAvatarStackWidth(0, 34, 26), 0);
     assert.equal(resolveAvatarStackWidth(1, 34, 26), 34);
     assert.equal(resolveAvatarStackWidth(5, 34, 26), 138);
+
+    assert.equal(
+      getContrastNotice("image"),
+      "Image not supported."
+    );
+
+    const namespacedByUser = resolvePreferenceNamespace({
+      userId: "123",
+      sessionId: 77,
+      widgetId: "widget-abc",
+    });
+    assert.equal(
+      namespacedByUser.mapKey,
+      "prefs:user:id:123:widget:widget-abc"
+    );
+    assert.deepEqual(namespacedByUser.legacyKeys, ["user:123", "user:session:77", "user:default"]);
+
+    const namespacedBySession = resolvePreferenceNamespace({
+      userId: null,
+      sessionId: 77,
+      widgetId: "widget-abc",
+    });
+    assert.equal(
+      namespacedBySession.mapKey,
+      "prefs:user:session:77:widget:widget-abc"
+    );
+    assert.deepEqual(namespacedBySession.legacyKeys, ["user:session:77", "user:default"]);
+
+    const namespacedAnonymous = resolvePreferenceNamespace({
+      userId: null,
+      sessionId: null,
+      widgetId: null,
+    });
+    assert.equal(
+      namespacedAnonymous.mapKey,
+      "prefs:user:anonymous:widget:unknown"
+    );
+    assert.deepEqual(namespacedAnonymous.legacyKeys, ["user:default"]);
 
     assert.equal(accentStepPolicy.stepSize, 100);
     assert.equal(accentStepPolicy.mode.light.primaryDirection, "darker");

--- a/widget-src/code.tsx
+++ b/widget-src/code.tsx
@@ -14,7 +14,6 @@ import legacyChecklistJson from "data/checklist.json";
 import { ChecklistPanel } from "components/checklist";
 import type { ChecklistDataType } from "types";
 import useProgressTracker from "hooks/useProgressTracker";
-import useDarkMode from "hooks/useDarkMode"; // Widgets have a hard time detecting dark mode from my experience
 import { useUserPreferences } from "hooks/useUserPreferences";
 import {
   applyLegacyOverrides,
@@ -39,7 +38,7 @@ import {
  */
 function Widget() {
   const { preferences, setPreferences } = useUserPreferences();
-  const { language, theme } = preferences;
+  const { language } = preferences;
 
   // Select appropriate data based on language
   let checklistData = (
@@ -61,9 +60,6 @@ function Widget() {
   // Use the progress tracker hook for state management
   const { taskCompletion, handleCheckChange } = useProgressTracker();
 
-  // Detect system dark mode preference (if available)
-  const isDarkMode = useDarkMode();
-
   // Flatten all items for progress tracking
   const allItems = checklistData.sections.flatMap((section) => section.items);
   const itemIds = allItems.map((item) => item.id);
@@ -71,13 +67,6 @@ function Widget() {
   // Calculate progress
   const total = itemIds.length;
   const completed = itemIds.filter((id) => taskCompletion[id]).length;
-
-  // Determine effective dark mode based on theme selection:
-  // - "light" → always light mode
-  // - "dark" → always dark mode
-  // - "system" → use detected system preference (defaults to light if unavailable)
-  const effectiveDarkMode =
-    theme === "dark" ? true : theme === "system" ? isDarkMode : false;
 
   return (
     <ChecklistPanel
@@ -87,7 +76,6 @@ function Widget() {
       handleCheckChange={handleCheckChange}
       total={total}
       completed={completed}
-      isDarkMode={effectiveDarkMode}
       showItemDescriptionsForSectionIds={legacySectionIds}
       preferences={preferences}
       setPreferences={setPreferences}

--- a/widget-src/components/checklist/ChecklistPanel.tsx
+++ b/widget-src/components/checklist/ChecklistPanel.tsx
@@ -331,11 +331,11 @@ function ChecklistPanel({
   const contrastStatusSuffixMin =
     contrastDisplay?.measurementMode === "sampled-min" ? " (min)" : "";
   const contrastStatusSuffixLarge =
-    contrastDisplay?.grade === "A" ? " | Large only" : "";
+    contrastDisplay?.grade === "A"
+      ? ` | ${String(t.contrastLargeTextOnly)}`
+      : "";
   const contrastStatusFullText = contrastStatusPrimary
-    ? `${contrastStatusPrimary}${contrastStatusSuffixMin}${
-        contrastDisplay?.grade === "A" ? ` | ${String(t.contrastLargeTextOnly)}` : ""
-      }`
+    ? `${contrastStatusPrimary}${contrastStatusSuffixMin}${contrastStatusSuffixLarge}`
     : null;
   const statusCandidates = contrastStatusPrimary
     ? [

--- a/widget-src/components/checklist/ChecklistPanel.tsx
+++ b/widget-src/components/checklist/ChecklistPanel.tsx
@@ -19,8 +19,47 @@ import type { ChecklistSectionType } from "types";
 import { useAvatarProfiles } from "hooks/useAvatarProfiles";
 import { getProgressLayout } from "logic/progress";
 import { useChecklistSettingsMenu } from "hooks/useChecklistSettingsMenu";
+import { useContrastChecker } from "hooks/useContrastChecker";
 import { buildA11yLogoSvg } from "ui/icons";
 import { resolveAvatarStackWidth, resolveAvatarStep } from "shared/avatarStack";
+
+function hexToColor(hex: string): RGB {
+  const raw = hex.replace("#", "");
+  const normalized =
+    raw.length === 3
+      ? raw
+          .split("")
+          .map((char) => `${char}${char}`)
+          .join("")
+      : raw.padEnd(6, "0").slice(0, 6);
+  const parseChannel = (start: number) =>
+    Number.parseInt(normalized.slice(start, start + 2), 16) / 255;
+  return {
+    r: parseChannel(0),
+    g: parseChannel(2),
+    b: parseChannel(4),
+  };
+}
+
+function buildLinearGradientPaint(
+  stops: Array<{ position: number; color: string; alpha: number }>
+) {
+  return {
+    type: "gradient-linear" as const,
+    gradientHandlePositions: [
+      { x: 0, y: 0.5 },
+      { x: 1, y: 0.5 },
+      { x: 0, y: 1 },
+    ] as [{ x: number; y: number }, { x: number; y: number }, { x: number; y: number }],
+    gradientStops: stops.map((stop) => ({
+      position: stop.position,
+      color: {
+        ...hexToColor(stop.color),
+        a: stop.alpha,
+      },
+    })),
+  };
+}
 
 /**
  * Renders the accessibility checklist panel, displaying categories and their associated tasks.
@@ -59,13 +98,18 @@ function ChecklistPanel({
   handleCheckChange,
   total,
   completed,
-  isDarkMode,
   showItemDescriptionsForSectionIds = [],
   preferences,
   setPreferences,
 }: ChecklistProps) {
-  const { hideCompleted, language, theme, selectedTemplate, accentColor } =
-    preferences;
+  const {
+    hideCompleted,
+    language,
+    theme,
+    selectedTemplate,
+    accentColor,
+    showContrastInspector,
+  } = preferences;
   const t = getMessages(language);
 
   // Search functionality
@@ -86,6 +130,14 @@ function ChecklistPanel({
     total,
     messages: t,
   });
+  const {
+    contrastResult,
+    contrastNotice,
+    contrastSwapped,
+    checkSelection,
+    clearResult,
+    toggleContrastSwap,
+  } = useContrastChecker();
 
   useChecklistSettingsMenu({
     preferences,
@@ -102,7 +154,7 @@ function ChecklistPanel({
    *
    * @returns {JSX.Element} The rendered Checklist component.
    */
-  const effectiveDark = theme === "dark" || (theme === "system" && isDarkMode);
+  const effectiveDark = theme === "dark";
   const matchedThemePreset = inferThemePresetFromAccent(accentColor);
   const themePreset = matchedThemePreset ?? "default";
   const accentOverride = matchedThemePreset ? undefined : accentColor;
@@ -129,6 +181,182 @@ function ChecklistPanel({
   const progressGap = ui.progress.gap;
   const progressTextColor = ui.progress.textColor ?? ui.colors.textPrimary;
   const progressLayoutText = progressTextSample;
+  const contrastSwapSupported = Boolean(contrastResult?.swappable);
+  const contrastDisplay = (() => {
+    if (!contrastResult) return null;
+    const swapped = contrastSwapped && contrastSwapSupported;
+    return {
+      foreground: swapped ? contrastResult.background : contrastResult.foreground,
+      background: swapped ? contrastResult.foreground : contrastResult.background,
+      foregroundKind: swapped
+        ? contrastResult.backgroundKind
+        : contrastResult.foregroundKind,
+      backgroundKind: swapped
+        ? contrastResult.foregroundKind
+        : contrastResult.backgroundKind,
+      foregroundStops: swapped
+        ? contrastResult.backgroundStops
+        : contrastResult.foregroundStops,
+      backgroundStops: swapped
+        ? contrastResult.foregroundStops
+        : contrastResult.backgroundStops,
+      foregroundStopCount: swapped
+        ? contrastResult.backgroundStopCount
+        : contrastResult.foregroundStopCount,
+      backgroundStopCount: swapped
+        ? contrastResult.foregroundStopCount
+        : contrastResult.backgroundStopCount,
+      ratioDisplay: contrastResult.ratioDisplay,
+      measurementMode: contrastResult.measurementMode,
+      grade: contrastResult.grade,
+    };
+  })();
+  const contrastPreviewFill =
+    contrastDisplay?.backgroundKind === "gradient" &&
+    contrastDisplay.backgroundStops &&
+    contrastDisplay.backgroundStops.length > 1
+      ? buildLinearGradientPaint(contrastDisplay.backgroundStops)
+      : contrastDisplay?.background ?? ui.colors.sectionDescBg;
+  const contrastPreviewText =
+    contrastDisplay?.foregroundKind === "gradient" &&
+    contrastDisplay.foregroundStops &&
+    contrastDisplay.foregroundStops.length > 1
+      ? buildLinearGradientPaint(contrastDisplay.foregroundStops)
+      : contrastDisplay?.foreground ?? ui.colors.textPrimary;
+  const contrastPreviewStatusText = contrastDisplay
+    ? contrastDisplay.grade === "A"
+      ? "Aa"
+      : contrastDisplay.grade
+    : "Aa";
+  const contrastResetDisabled =
+    !contrastResult && !contrastNotice && !contrastSwapped;
+  const contrastBlockGap = ui.section.headerGap;
+  const contrastPreviewActionsGap = ui.section.bulkAction.gap;
+  const contrastMetaGap = ui.section.bulkAction.gap;
+  const contrastPreviewWidth = ui.inspector.previewWidth;
+  const contrastControlPadding = ui.section.bulkAction.padding;
+  const contrastActionPadding = {
+    top: ui.section.headerGap,
+    // Add subtle bottom bias for hover fill without moving text baseline.
+    bottom: contrastControlPadding + 2,
+    left: contrastControlPadding,
+    right: contrastControlPadding,
+  };
+  const contrastUiTextColor = ui.inspector.colors.hintText;
+  const formatGradientSummary = (
+    stops:
+      | Array<{ position: number; color: string; alpha: number }>
+      | undefined
+      | null
+  ): string => {
+    const values = (stops ?? []).map((stop) => stop.color);
+    if (values.length === 0) {
+      return "Gradient 0 steps";
+    }
+    const sample = values.slice(0, 2);
+    const remaining = values.length - sample.length;
+    return `Gradient ${values.length} steps, ${sample.join(", ")}${
+      remaining > 0 ? `, ${remaining}+` : ""
+    }`;
+  };
+  const formatGradientTooltip = (
+    stops:
+      | Array<{ position: number; color: string; alpha: number }>
+      | undefined
+      | null
+  ): string | undefined => {
+    if (!stops || stops.length === 0) return undefined;
+    return stops
+      .map((stop, index) => {
+        const percent = Math.round(stop.position * 100);
+        return `${index + 1}. ${stop.color} @ ${percent}%`;
+      })
+      .join("\n");
+  };
+  const describeFill = (
+    kind: "solid" | "gradient" | undefined,
+    value: string | null,
+    stops: number | undefined,
+    gradientStops:
+      | Array<{ position: number; color: string; alpha: number }>
+      | undefined
+      | null
+  ): string => {
+    if (!value) return String(t.contrastNoData);
+    if (kind === "gradient") {
+      if (gradientStops && gradientStops.length > 0) {
+        return formatGradientSummary(gradientStops);
+      }
+      return `Gradient ${stops ?? 0} steps`;
+    }
+    return value;
+  };
+  const contrastForegroundLabel = contrastDisplay
+    ? describeFill(
+        contrastDisplay.foregroundKind,
+        contrastDisplay.foreground,
+        contrastDisplay.foregroundStopCount,
+        contrastDisplay.foregroundStops
+      )
+    : null;
+  const contrastBackgroundLabel = contrastDisplay
+    ? describeFill(
+        contrastDisplay.backgroundKind,
+        contrastDisplay.background,
+        contrastDisplay.backgroundStopCount,
+        contrastDisplay.backgroundStops
+      )
+    : null;
+  const contrastForegroundTooltip =
+    contrastDisplay?.foregroundKind === "gradient"
+      ? formatGradientTooltip(contrastDisplay.foregroundStops)
+      : undefined;
+  const contrastBackgroundTooltip =
+    contrastDisplay?.backgroundKind === "gradient"
+      ? formatGradientTooltip(contrastDisplay.backgroundStops)
+      : undefined;
+  const contrastTextLabel = `${String(t.contrastTextLabel)}:`;
+  const contrastBackgroundLabelText = `${String(t.contrastBackgroundLabel)}:`;
+  const contrastMetaPlaceholder = "N/A";
+  const contrastTextValue = contrastDisplay
+    ? contrastForegroundLabel ?? String(t.contrastNoData)
+    : contrastMetaPlaceholder;
+  const contrastBackgroundValue = contrastDisplay
+    ? contrastBackgroundLabel ?? String(t.contrastNoData)
+    : contrastMetaPlaceholder;
+  const showContrastMeta = true;
+  const contrastStatusPrimary = contrastDisplay
+    ? `Contrast ${contrastDisplay.ratioDisplay}:1`
+    : null;
+  const contrastStatusSuffixMin =
+    contrastDisplay?.measurementMode === "sampled-min" ? " (min)" : "";
+  const contrastStatusSuffixLarge =
+    contrastDisplay?.grade === "A" ? " | Large only" : "";
+  const contrastStatusFullText = contrastStatusPrimary
+    ? `${contrastStatusPrimary}${contrastStatusSuffixMin}${
+        contrastDisplay?.grade === "A" ? ` | ${String(t.contrastLargeTextOnly)}` : ""
+      }`
+    : null;
+  const statusCandidates = contrastStatusPrimary
+    ? [
+        `${contrastStatusPrimary}${contrastStatusSuffixMin}${contrastStatusSuffixLarge}`,
+        `${contrastStatusPrimary}${contrastStatusSuffixMin}`,
+        contrastStatusPrimary,
+      ]
+    : [];
+  const contrastStatusCellWidth = Math.floor(contrastPreviewWidth / 2);
+  const statusCharBudget = Math.max(16, Math.floor((contrastStatusCellWidth - 12) / 7));
+  const contrastStatusCandidate = statusCandidates.find(
+    (candidate) => candidate.length <= statusCharBudget
+  );
+  const contrastStatusText =
+    contrastStatusCandidate ??
+    (statusCandidates.length > 0 ? statusCandidates[statusCandidates.length - 1] : null);
+  const contrastStatusColor = ui.colors.progressFill;
+  const contrastStatusWeight = ui.progressTracker.fontWeight;
+  const contrastResolvedStatus = contrastNotice ?? contrastStatusText ?? "Contrast: N/A";
+  const contrastStatusTooltip = contrastNotice ?? contrastStatusFullText ?? undefined;
+
   const { textWidth: progressTextWidth, barWidth: progressBarWidth } =
     getProgressLayout({
       text: progressLayoutText,
@@ -139,21 +367,40 @@ function ChecklistPanel({
       textCharWidth: ui.progress.textCharWidth,
     });
 
-  const { avatars, recordInteraction } = useAvatarProfiles({
+  const { avatars, overflowCount, overflowNames, recordInteraction } = useAvatarProfiles({
     accentColor: ui.colors.progressFill,
     neutralDark: neutral.gray[900],
     neutralLight: neutral.white,
     max: ui.header.avatar.maxVisible,
   });
+  const avatarOutlineColor = headerText;
   const avatarSize = ui.header.avatar.size;
   const avatarStroke = ui.header.avatar.strokeWidth;
   const avatarStep = resolveAvatarStep(avatarSize, ui.header.avatar.stackOffsetX);
+  const avatarEntries: Array<
+    | (typeof avatars)[number]
+    | { id: string; name: string; type: "overflow"; label: string }
+  > =
+    overflowCount > 0
+      ? [
+          ...avatars,
+          {
+            id: "avatar-overflow",
+            name:
+              overflowNames.length > 0
+                ? `${overflowCount} more users: ${overflowNames.join(", ")}`
+                : `${overflowCount} more users`,
+            type: "overflow",
+            label: `+${overflowCount}`,
+          },
+        ]
+      : avatars;
   const avatarStackWidth = resolveAvatarStackWidth(
-    avatars.length,
+    avatarEntries.length,
     avatarSize,
     avatarStep
   );
-  const avatarPositions = avatars.map((avatar, index) => ({
+  const avatarPositions = avatarEntries.map((avatar, index) => ({
     avatar,
     x: index * avatarStep,
   }));
@@ -225,6 +472,43 @@ function ChecklistPanel({
                 0,
                 ui.header.avatar.radius - avatarStroke
               );
+              if (avatar.type === "overflow") {
+                return (
+                  <AutoLayout
+                    key={avatar.id}
+                    name="UserOverflow"
+                    tooltip={avatar.name}
+                    x={x}
+                    y={0}
+                    width={avatarSize}
+                    height={avatarSize}
+                    cornerRadius={ui.header.avatar.radius}
+                    stroke={avatarOutlineColor}
+                    strokeAlign="inside"
+                    strokeWidth={avatarStroke}
+                    verticalAlignItems="center"
+                    horizontalAlignItems="center"
+                  >
+                    <AutoLayout
+                      width={innerSize}
+                      height={innerSize}
+                      cornerRadius={innerRadius}
+                      fill={ui.colors.sectionDescBg}
+                      verticalAlignItems="center"
+                      horizontalAlignItems="center"
+                    >
+                      <Text
+                        fontSize={ui.header.avatar.fontSize}
+                        fontWeight={ui.header.avatar.fontWeight}
+                        fontFamily={ui.header.title.fontFamily}
+                        fill={ui.colors.textPrimary}
+                      >
+                        {avatar.label}
+                      </Text>
+                    </AutoLayout>
+                  </AutoLayout>
+                );
+              }
               if (avatar.type === "image" && avatar.src) {
                 return (
                   <AutoLayout
@@ -236,7 +520,8 @@ function ChecklistPanel({
                     width={avatarSize}
                     height={avatarSize}
                     cornerRadius={ui.header.avatar.radius}
-                    stroke={ui.colors.panelStroke}
+                    stroke={avatarOutlineColor}
+                    strokeAlign="inside"
                     strokeWidth={avatarStroke}
                     verticalAlignItems="center"
                     horizontalAlignItems="center"
@@ -260,7 +545,8 @@ function ChecklistPanel({
                   width={avatarSize}
                   height={avatarSize}
                   cornerRadius={ui.header.avatar.radius}
-                  stroke={ui.colors.panelStroke}
+                  stroke={avatarOutlineColor}
+                  strokeAlign="inside"
                   strokeWidth={avatarStroke}
                   verticalAlignItems="center"
                   horizontalAlignItems="center"
@@ -401,6 +687,222 @@ function ChecklistPanel({
             </Text>
           </AutoLayout>
         </AutoLayout>
+        {showContrastInspector ? (
+          <AutoLayout
+            direction="vertical"
+            spacing={contrastBlockGap}
+            width="fill-parent"
+            padding={{
+              top: ui.section.headerGap,
+              bottom: ui.progress.paddingBottom + ui.section.bulkAction.gap,
+              left: 0,
+              right: 0,
+            }}
+          >
+            <Text
+              fill={ui.inspector.colors.hintText}
+              fontFamily={ui.section.bulkAction.fontFamily}
+              fontSize={ui.item.text.fontSize}
+              fontWeight={ui.section.bulkAction.fontWeight}
+            >
+              {String(t.contrastInspectorHint)}
+            </Text>
+            <AutoLayout direction="vertical" spacing={contrastPreviewActionsGap} width="fill-parent">
+              <AutoLayout
+                width={contrastPreviewWidth}
+                height={ui.inspector.previewHeight}
+                fill={contrastPreviewFill}
+                cornerRadius={ui.inspector.previewRadius}
+                verticalAlignItems="center"
+                horizontalAlignItems="center"
+              >
+                <AutoLayout
+                  width="fill-parent"
+                  height="fill-parent"
+                  verticalAlignItems="center"
+                  horizontalAlignItems="center"
+                >
+                  <Text
+                    horizontalAlignText="center"
+                    fill={contrastPreviewText}
+                    fontFamily={ui.inspector.status.fontFamily}
+                    fontSize={ui.inspector.status.fontSize}
+                    fontWeight={ui.inspector.status.fontWeight}
+                    lineHeight={ui.inspector.status.lineHeight}
+                  >
+                    {contrastPreviewStatusText}
+                  </Text>
+                </AutoLayout>
+              </AutoLayout>
+              <AutoLayout
+                direction="horizontal"
+                width={contrastPreviewWidth}
+                height={ui.inspector.controls.height}
+                spacing={0}
+                verticalAlignItems="center"
+              >
+                <AutoLayout
+                  width={contrastStatusCellWidth}
+                  height="fill-parent"
+                  direction="horizontal"
+                  spacing={ui.inspector.controls.gap}
+                  verticalAlignItems="center"
+                >
+                  <AutoLayout
+                    onClick={checkSelection}
+                    height="fill-parent"
+                    padding={contrastActionPadding}
+                    cornerRadius={ui.section.bulkAction.radius}
+                    hoverStyle={{
+                      fill: ui.colors.hoverBg,
+                    }}
+                    horizontalAlignItems="center"
+                  >
+                    <Text
+                      fill={contrastUiTextColor}
+                      fontFamily={ui.section.bulkAction.fontFamily}
+                      fontSize={ui.progress.text.fontSize}
+                      fontWeight={ui.section.bulkAction.fontWeight}
+                    >
+                      {String(t.contrastRunCheck)}
+                    </Text>
+                  </AutoLayout>
+                  <AutoLayout
+                    onClick={contrastSwapSupported ? toggleContrastSwap : undefined}
+                    opacity={contrastSwapSupported ? 1 : 0.5}
+                    height="fill-parent"
+                    padding={contrastActionPadding}
+                    cornerRadius={ui.section.bulkAction.radius}
+                    {...(contrastSwapSupported
+                      ? {
+                          hoverStyle: {
+                            fill: ui.colors.hoverBg,
+                          },
+                        }
+                      : {})}
+                    horizontalAlignItems="center"
+                  >
+                    <Text
+                      fill={contrastUiTextColor}
+                      fontFamily={ui.section.bulkAction.fontFamily}
+                      fontSize={ui.progress.text.fontSize}
+                      fontWeight={ui.section.bulkAction.fontWeight}
+                    >
+                      {String(t.contrastSwap)}
+                    </Text>
+                  </AutoLayout>
+                  <AutoLayout
+                    onClick={!contrastResetDisabled ? clearResult : undefined}
+                    opacity={contrastResetDisabled ? 0.5 : 1}
+                    height="fill-parent"
+                    padding={contrastActionPadding}
+                    cornerRadius={ui.section.bulkAction.radius}
+                    {...(!contrastResetDisabled
+                      ? {
+                          hoverStyle: {
+                            fill: ui.colors.hoverBg,
+                          },
+                        }
+                      : {})}
+                    horizontalAlignItems="center"
+                  >
+                    <Text
+                      fill={contrastUiTextColor}
+                      fontFamily={ui.section.bulkAction.fontFamily}
+                      fontSize={ui.progress.text.fontSize}
+                      fontWeight={ui.section.bulkAction.fontWeight}
+                    >
+                      {String(t.contrastClear)}
+                    </Text>
+                  </AutoLayout>
+                </AutoLayout>
+                <AutoLayout
+                  width={contrastPreviewWidth - contrastStatusCellWidth}
+                  height="fill-parent"
+                  verticalAlignItems="center"
+                >
+                  <Text
+                    fill={contrastStatusColor}
+                    opacity={1}
+                    fontFamily={ui.progress.text.fontFamily}
+                    fontSize={ui.progress.text.fontSize}
+                    fontWeight={contrastStatusWeight}
+                    width="fill-parent"
+                    horizontalAlignText="right"
+                    truncate={1}
+                    tooltip={contrastStatusTooltip}
+                  >
+                    {contrastResolvedStatus}
+                  </Text>
+                </AutoLayout>
+              </AutoLayout>
+            </AutoLayout>
+            <AutoLayout
+              direction="vertical"
+              spacing={contrastMetaGap}
+              width="fill-parent"
+              fill={ui.colors.sectionDescBg}
+              cornerRadius={ui.section.description.radius}
+              padding={{
+                vertical: ui.section.description.paddingY,
+                horizontal: ui.section.description.paddingX,
+              }}
+            >
+              <AutoLayout
+                tooltip={contrastForegroundTooltip}
+                direction="horizontal"
+                spacing={ui.section.bulkAction.gap}
+                width="fill-parent"
+                verticalAlignItems="center"
+              >
+                <Text
+                  fill={contrastUiTextColor}
+                  opacity={showContrastMeta ? 1 : 0}
+                  fontFamily={ui.progress.text.fontFamily}
+                  fontSize={ui.section.bulkAction.fontSize}
+                  fontWeight={ui.section.title.fontWeight}
+                >
+                  {contrastTextLabel}
+                </Text>
+                <Text
+                  fill={contrastUiTextColor}
+                  opacity={showContrastMeta ? 1 : 0}
+                  fontFamily={ui.progress.text.fontFamily}
+                  fontSize={ui.section.bulkAction.fontSize}
+                  fontWeight={ui.section.bulkAction.fontWeight}
+                >
+                  {contrastTextValue}
+                </Text>
+              </AutoLayout>
+              <AutoLayout
+                tooltip={contrastBackgroundTooltip}
+                direction="horizontal"
+                spacing={ui.section.bulkAction.gap}
+                width="fill-parent"
+                verticalAlignItems="center"
+              >
+                <Text
+                  fill={contrastUiTextColor}
+                  opacity={showContrastMeta ? 1 : 0}
+                  fontFamily={ui.progress.text.fontFamily}
+                  fontSize={ui.section.bulkAction.fontSize}
+                  fontWeight={ui.section.title.fontWeight}
+                >
+                  {contrastBackgroundLabelText}
+                </Text>
+                <Text
+                  fill={contrastUiTextColor}
+                  opacity={showContrastMeta ? 1 : 0}
+                  fontFamily={ui.progress.text.fontFamily}
+                  fontSize={ui.section.bulkAction.fontSize}
+                  fontWeight={ui.section.bulkAction.fontWeight}
+                >
+                  {contrastBackgroundValue}
+                </Text>
+              </AutoLayout>
+            </AutoLayout>
+          </AutoLayout>
+        ) : null}
         {templateFilteredSections.length === 0 ? (
           <Text
             fill={ui.colors.textPrimary}

--- a/widget-src/design-system/components/checklist.ts
+++ b/widget-src/design-system/components/checklist.ts
@@ -2,6 +2,8 @@ import { padding, gap, radius, sizes } from "../spacing";
 import { fontSize, fontWeight, fontFamily } from "../primitives/typography";
 import { borderWidth, borderRadius } from "../primitives/borders";
 import { dimensions } from "../primitives/sizing";
+import { gray, pure } from "../primitives/color";
+import { calculateContrastRatioHex } from "../utils/contrast";
 
 export type ChecklistThemeVariables = {
   panelBg: string;
@@ -184,6 +186,24 @@ type ChecklistLayoutVariables = {
     fontWeight: WidgetJSX.FontWeight;
     gap: number;
   };
+  inspector: {
+    previewWidth: number;
+    previewHeight: number;
+    previewRadius: number;
+    status: {
+      fontFamily: string;
+      fontSize: number;
+      fontWeight: WidgetJSX.FontWeight;
+      lineHeight?: string;
+    };
+    controls: {
+      height: number;
+      paddingX: number;
+      gap: number;
+      radius: number;
+      strokeWidth: number;
+    };
+  };
 };
 
 const companionLayout: ChecklistLayoutVariables = {
@@ -209,13 +229,13 @@ const companionLayout: ChecklistLayoutVariables = {
       letterSpacing: -0.3,
     },
     avatar: {
-      size: dimensions.avatarMd + 2,
+      size: dimensions.avatarMd,
       radius: borderRadius.full,
       strokeWidth: borderWidth.base,
       fontSize: fontSize.xs,
-      fontWeight: fontWeight.semibold,
+      fontWeight: fontWeight.bold,
       stackOffsetX: -8,
-      maxVisible: 5,
+      maxVisible: 4,
     },
   },
   search: {
@@ -341,10 +361,62 @@ const companionLayout: ChecklistLayoutVariables = {
     fontWeight: fontWeight.bold,
     gap: gap.compact,
   },
+  inspector: {
+    previewWidth: 352,
+    previewHeight: 200,
+    previewRadius: radius.lg,
+    status: {
+      fontFamily: fontFamily.sans,
+      fontSize: 64,
+      fontWeight: fontWeight.medium,
+      lineHeight: "100%",
+    },
+    controls: {
+      height: gap.major,
+      paddingX: gap.tight,
+      gap: gap.tight,
+      radius: radius.sm,
+      strokeWidth: borderWidth.base,
+    },
+  },
 };
+
+function pickReadableColor(background: string, preferred: string): string {
+  const preferredRatio = calculateContrastRatioHex(preferred, background);
+  if (typeof preferredRatio === "number" && preferredRatio >= 3) {
+    return preferred;
+  }
+  const darkRatio = calculateContrastRatioHex(gray[900], background);
+  const lightRatio = calculateContrastRatioHex(pure.white, background);
+  const darkValue = typeof darkRatio === "number" ? darkRatio : 0;
+  const lightValue = typeof lightRatio === "number" ? lightRatio : 0;
+  return darkValue >= lightValue ? gray[900] : pure.white;
+}
 
 export function createChecklistVariables(theme: ChecklistThemeVariables) {
   const layout = companionLayout;
+  const inspectorSurface = pure.white;
+  const inspectorActionActiveBg = theme.progressFill;
+  const inspectorActionText = pickReadableColor(
+    inspectorSurface,
+    theme.textPrimary,
+  );
+  const inspectorActionActiveText = pickReadableColor(
+    inspectorActionActiveBg,
+    theme.panelBg,
+  );
+  const panelContrastWithWhite = calculateContrastRatioHex(
+    theme.panelBg,
+    pure.white,
+  );
+  const panelContrastWithDark = calculateContrastRatioHex(
+    theme.panelBg,
+    gray[900],
+  );
+  const shouldUseLightInspectorText =
+    (typeof panelContrastWithWhite === "number" ? panelContrastWithWhite : 0) >=
+    (typeof panelContrastWithDark === "number" ? panelContrastWithDark : 0);
+  const inspectorHintText = shouldUseLightInspectorText ? "#FAFAFA" : "#404040";
   return {
     colors: {
       panelBg: theme.panelBg,
@@ -420,6 +492,18 @@ export function createChecklistVariables(theme: ChecklistThemeVariables) {
     },
     progressTracker: {
       ...layout.progressTracker,
+    },
+    inspector: {
+      ...layout.inspector,
+      colors: {
+        surface: inspectorSurface,
+        surfaceStroke: theme.panelStroke,
+        hintText: inspectorHintText,
+        actionText: inspectorActionText,
+        actionTextDisabled: gray[500],
+        actionActiveBg: inspectorActionActiveBg,
+        actionActiveText: inspectorActionActiveText,
+      },
     },
   } as const;
 }

--- a/widget-src/hooks/useAvatarProfiles.ts
+++ b/widget-src/hooks/useAvatarProfiles.ts
@@ -78,13 +78,18 @@ const TEST_AVATAR_NAMES = [
   "Kai Demo",
   "Riley QA",
   "Morgan UX",
+  "Jordan Dev",
+  "Taylor Ops",
+  "Casey PM",
+  "Sam Review",
+  "Alex Design",
 ];
 const TEST_AVATAR_COLORS = [
   defaultTheme.brand.purple[100],
   defaultTheme.neutral.gray[100],
   defaultTheme.semantic.success.light,
   defaultTheme.semantic.warning.light,
-  defaultTheme.semantic.info.light,
+  defaultTheme.neutral.gray[900],
 ];
 
 export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
@@ -98,7 +103,7 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
     "avatarTestSeeded",
     false
   );
-  const limitedAvatarIds = capAvatarIds(avatarIds, max);
+  const visibleAvatarIds = capAvatarIds(avatarIds, max);
 
   const upsertAvatar = (profile: AvatarProfile) => {
     const existing = avatarProfiles.get(profile.id);
@@ -112,11 +117,8 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
     if (hasChanges) {
       avatarProfiles.set(profile.id, profile);
     }
-    const nextIds = capAvatarIds(
-      [profile.id, ...avatarIds.filter((id) => id !== profile.id)],
-      max
-    );
-    if (nextIds.join("|") !== limitedAvatarIds.join("|")) {
+    const nextIds = [profile.id, ...avatarIds.filter((id) => id !== profile.id)];
+    if (nextIds.join("|") !== avatarIds.join("|")) {
       setAvatarIds(nextIds);
     }
   };
@@ -141,8 +143,12 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
   };
 
   useEffect(() => {
-    if (!ENABLE_TEST_AVATARS || seeded) return;
-    const nextIds = [...limitedAvatarIds];
+    if (!ENABLE_TEST_AVATARS) return;
+    const hasAllTestAvatarIds = TEST_AVATAR_NAMES.every((_, index) =>
+      avatarIds.includes(`test:${index + 1}`)
+    );
+    if (seeded && hasAllTestAvatarIds) return;
+    const nextIds = [...avatarIds];
     TEST_AVATAR_NAMES.forEach((name, index) => {
       const id = `test:${index + 1}`;
       const existing = avatarProfiles.get(id);
@@ -160,22 +166,22 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
         nextIds.push(id);
       }
     });
-    if (nextIds.join("|") !== limitedAvatarIds.join("|")) {
-      setAvatarIds(capAvatarIds(nextIds, max));
+    if (nextIds.join("|") !== avatarIds.join("|")) {
+      setAvatarIds(nextIds);
     }
-    setSeeded(true);
+    if (!seeded) {
+      setSeeded(true);
+    }
   });
 
-  // Enforce avatar cap for older synced data that may exceed the current max.
-  useEffect(() => {
-    const cappedAvatarIds = capAvatarIds(avatarIds, max);
-    if (avatarIds.join("|") === cappedAvatarIds.join("|")) return;
-    setAvatarIds(cappedAvatarIds);
-  });
-
-  const profiles = limitedAvatarIds
+  const profiles = visibleAvatarIds
     .map((id) => avatarProfiles.get(id))
     .filter((profile): profile is AvatarProfile => Boolean(profile));
+  const overflowCount = Math.max(0, avatarIds.length - profiles.length);
+  const overflowNames = avatarIds
+    .slice(visibleAvatarIds.length)
+    .map((id) => avatarProfiles.get(id)?.name?.trim() ?? "")
+    .filter((name) => name.length > 0);
 
   const avatars: AvatarDisplay[] = profiles.map((profile) => {
     if (profile.photoUrl) {
@@ -198,5 +204,5 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
     };
   });
 
-  return { avatars, recordInteraction };
+  return { avatars, overflowCount, overflowNames, recordInteraction };
 }

--- a/widget-src/hooks/useChecklistSettingsMenu.ts
+++ b/widget-src/hooks/useChecklistSettingsMenu.ts
@@ -52,6 +52,7 @@ export function useChecklistSettingsMenu({
     theme,
     selectedTemplate,
     accentColor,
+    showContrastInspector,
   } = preferences;
 
   const templateKeyMap: Record<TemplateType, keyof typeof messages.templates> =
@@ -73,15 +74,52 @@ export function useChecklistSettingsMenu({
     /:\s*$/,
     ""
   );
-
   usePropertyMenu(
     [
+      // Section 1: Scope & Context
+      {
+        itemType: "dropdown",
+        propertyName: "language",
+        tooltip: messages.languageLabel,
+        selectedOption: language,
+        options: [
+          { option: "en", label: "English" },
+          { option: "es", label: "Español" },
+        ],
+      },
       {
         itemType: "dropdown",
         propertyName: "template",
         tooltip: templateTooltip || "Checklist Template",
         selectedOption: selectedTemplate,
         options: templateOptions,
+      },
+      { itemType: "separator" },
+      // Section 2: Visual Configuration
+      {
+        itemType: "dropdown",
+        propertyName: "theme",
+        tooltip: messages.themeLabel,
+        selectedOption: theme,
+        options: [
+          { option: "light", label: "Light" },
+          { option: "dark", label: "Dark" },
+        ],
+      },
+      {
+        itemType: "color-selector",
+        propertyName: "accentColor",
+        tooltip: messages.brandThemeLabel,
+        selectedOption: accentColor,
+        options: COLOR_SELECTOR_OPTIONS,
+      },
+      { itemType: "separator" },
+      // Section 3: Specialized Checks & Exports
+      {
+        itemType: "toggle",
+        propertyName: "contrast-inspector",
+        tooltip: messages.contrastInspectorToggle,
+        isToggled: showContrastInspector,
       },
       {
         itemType: "action",
@@ -96,34 +134,6 @@ export function useChecklistSettingsMenu({
         isToggled: hideCompleted,
       },
       */
-      {
-        itemType: "dropdown",
-        propertyName: "theme",
-        tooltip: messages.themeLabel,
-        selectedOption: theme,
-        options: [
-          { option: "light", label: "Light" },
-          { option: "dark", label: "Dark" },
-          { option: "system", label: "System" },
-        ],
-      },
-      {
-        itemType: "dropdown",
-        propertyName: "language",
-        tooltip: messages.languageLabel,
-        selectedOption: language,
-        options: [
-          { option: "en", label: "English" },
-          { option: "es", label: "Español" },
-        ],
-      },
-      {
-        itemType: "color-selector",
-        propertyName: "accentColor",
-        tooltip: messages.brandThemeLabel,
-        selectedOption: accentColor,
-        options: COLOR_SELECTOR_OPTIONS,
-      },
     ],
     (event: { propertyName: string; propertyValue?: string }) => {
       const { propertyName, propertyValue } = event;
@@ -139,13 +149,16 @@ export function useChecklistSettingsMenu({
         }
       }
       if (propertyName === "theme" && propertyValue) {
-        setPreferences({ theme: propertyValue as "light" | "dark" | "system" });
+        setPreferences({ theme: propertyValue as "light" | "dark" });
       }
       if (propertyName === "language" && propertyValue) {
         setPreferences({ language: propertyValue as "en" | "es" });
       }
       if (propertyName === "accentColor" && propertyValue) {
         setPreferences({ accentColor: propertyValue });
+      }
+      if (propertyName === "contrast-inspector") {
+        setPreferences({ showContrastInspector: !showContrastInspector });
       }
     }
   );

--- a/widget-src/hooks/useContrastChecker.ts
+++ b/widget-src/hooks/useContrastChecker.ts
@@ -6,16 +6,84 @@
  *
  * @since 1.2.0
  */
+import {
+  getContrastNotice,
+  type ContrastUnsupportedReason,
+} from "shared/contrastMessages";
+
 const { widget } = figma;
 const { useSyncedState } = widget;
 
+type ColorKind = "solid" | "gradient";
+type ContrastGrade = "AAA" | "AA" | "A" | "Failed";
+type ContrastMeasurementMode = "exact" | "sampled-min";
+
 export interface ContrastResult {
   ratio: number;
+  ratioRaw: number;
+  ratioDisplay: string;
+  grade: ContrastGrade;
+  measurementMode: ContrastMeasurementMode;
+  swappable: boolean;
   passesAA: boolean;
   passesAAA: boolean;
   foreground: string;
   background: string;
+  foregroundKind: ColorKind;
+  foregroundStopCount?: number;
+  foregroundStops?: Array<{
+    position: number;
+    color: string;
+    alpha: number;
+  }>;
+  backgroundKind: ColorKind;
+  backgroundStopCount?: number;
+  backgroundStops?: Array<{
+    position: number;
+    color: string;
+    alpha: number;
+  }>;
   suggestion?: string;
+}
+
+type RgbaSample = {
+  color: RGB;
+  alpha: number;
+  position?: number;
+};
+
+type PaintResolution =
+  | { status: "none" }
+  | { status: "image" }
+  | { status: "mixed" }
+  | { status: "multi" }
+  | {
+      status: "ok";
+      kind: ColorKind;
+      samples: RgbaSample[];
+    };
+
+type ContrastResolution =
+  | {
+      kind: "result";
+      result: ContrastResult;
+    }
+  | {
+      kind: "unsupported";
+      reason: ContrastUnsupportedReason;
+    };
+
+const GRADIENT_TYPES = new Set<Paint["type"]>([
+  "GRADIENT_LINEAR",
+  "GRADIENT_RADIAL",
+  "GRADIENT_ANGULAR",
+  "GRADIENT_DIAMOND",
+]);
+
+function paintSupportsContrastSample(
+  paint: Paint
+): paint is SolidPaint | GradientPaint {
+  return paint.type === "SOLID" || GRADIENT_TYPES.has(paint.type);
 }
 
 /**
@@ -49,21 +117,109 @@ function getContrastRatio(color1: RGB, color2: RGB): number {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
-/**
- * Extracts solid color from Paint object.
- */
-function extractColor(
-  paint: Paint | readonly Paint[] | typeof figma.mixed
-): RGB | null {
-  if (!paint || paint === figma.mixed) return null;
+function clampAlpha(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.max(0, Math.min(1, value));
+}
+
+function extractRgbaSamplesFromPaint(
+  paint: SolidPaint | GradientPaint
+): RgbaSample[] {
+  if (paint.visible === false) return [];
+
+  if (paint.type === "SOLID") {
+    return [
+      {
+        color: paint.color,
+        alpha: clampAlpha(paint.opacity ?? 1),
+      },
+    ];
+  }
+
+  const paintOpacity = clampAlpha(paint.opacity ?? 1);
+  return paint.gradientStops.map((stop) => ({
+    color: {
+      r: stop.color.r,
+      g: stop.color.g,
+      b: stop.color.b,
+    },
+    alpha: clampAlpha(paintOpacity * clampAlpha(stop.color.a ?? 1)),
+    position: stop.position,
+  }));
+}
+
+function resolvePaint(
+  paint: Paint | readonly Paint[] | typeof figma.mixed | null
+): PaintResolution {
+  if (!paint) return { status: "none" };
+  if (paint === figma.mixed) return { status: "mixed" };
 
   const paints = Array.isArray(paint) ? paint : [paint];
-  const solidPaint = paints.find(
-    (p) => p.type === "SOLID" && p.visible !== false
-  ) as SolidPaint | undefined;
+  const visible = paints.filter((entry) => entry.visible !== false);
+  if (visible.length === 0) return { status: "none" };
 
-  if (!solidPaint) return null;
-  return solidPaint.color;
+  if (visible.some((entry) => entry.type === "IMAGE")) {
+    return { status: "image" };
+  }
+
+  const supported = visible.filter((entry) => paintSupportsContrastSample(entry));
+  if (supported.length === 0) return { status: "none" };
+
+  // Multiple visible paints require full compositing and are not reliable here.
+  if (supported.length > 1 || supported.length !== visible.length) {
+    return { status: "multi" };
+  }
+
+  const source = supported[0];
+  const samples = extractRgbaSamplesFromPaint(source);
+  if (samples.length === 0) return { status: "none" };
+
+  return {
+    status: "ok",
+    kind: source.type === "SOLID" ? "solid" : "gradient",
+    samples,
+  };
+}
+
+function toUnsupportedReason(
+  status: Exclude<PaintResolution["status"], "ok" | "none">
+): ContrastUnsupportedReason {
+  switch (status) {
+    case "image":
+      return "image";
+    case "mixed":
+      return "mixed-fills";
+    case "multi":
+      return "multi-fills";
+  }
+}
+
+function blendOver(foreground: RGB, background: RGB, alpha: number): RGB {
+  const a = clampAlpha(alpha);
+  return {
+    r: foreground.r * a + background.r * (1 - a),
+    g: foreground.g * a + background.g * (1 - a),
+    b: foreground.b * a + background.b * (1 - a),
+  };
+}
+
+function colorsClose(a: RGB, b: RGB, epsilon = 0.0005): boolean {
+  return (
+    Math.abs(a.r - b.r) <= epsilon &&
+    Math.abs(a.g - b.g) <= epsilon &&
+    Math.abs(a.b - b.b) <= epsilon
+  );
+}
+
+function samplesEquivalent(left: RgbaSample[], right: RgbaSample[]): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    const a = left[index];
+    const b = right[index];
+    if (!colorsClose(a.color, b.color)) return false;
+    if (Math.abs(a.alpha - b.alpha) > 0.001) return false;
+  }
+  return true;
 }
 
 /**
@@ -82,13 +238,345 @@ function rgbToHex(color: RGB): string {
   return `#${r}${g}${b}`.toUpperCase();
 }
 
+function formatRatioDisplay(ratioRaw: number): string {
+  // Do not round up threshold decisions in UI representation.
+  const truncated = Math.floor(ratioRaw * 100) / 100;
+  return truncated.toFixed(2);
+}
+
+function resolveGrade(ratioRaw: number): ContrastGrade {
+  if (ratioRaw >= 7) return "AAA";
+  if (ratioRaw >= 4.5) return "AA";
+  if (ratioRaw >= 3) return "A";
+  return "Failed";
+}
+
+function buildContrastResult(
+  ratioRaw: number,
+  foreground: RGB,
+  background: RGB,
+  foregroundKind: ColorKind,
+  backgroundKind: ColorKind,
+  swappable: boolean,
+  foregroundStops?: ContrastResult["foregroundStops"],
+  backgroundStops?: ContrastResult["backgroundStops"]
+): ContrastResult {
+  const grade = resolveGrade(ratioRaw);
+  const passesAA = ratioRaw >= 4.5;
+  const passesAAA = ratioRaw >= 7;
+
+  let suggestion = "";
+  if (ratioRaw < 3) {
+    suggestion = "Contrast too low. Increase difference between colors.";
+  } else if (ratioRaw < 4.5) {
+    suggestion = "Large text only. Increase contrast for normal-size AA.";
+  } else if (ratioRaw < 7) {
+    suggestion = "Meets AA. Increase contrast for AAA.";
+  }
+
+  return {
+    ratio: ratioRaw,
+    ratioRaw,
+    ratioDisplay: formatRatioDisplay(ratioRaw),
+    grade,
+    measurementMode:
+      foregroundKind === "solid" && backgroundKind === "solid"
+        ? "exact"
+        : "sampled-min",
+    swappable,
+    passesAA,
+    passesAAA,
+    foreground: rgbToHex(foreground),
+    background: rgbToHex(background),
+    foregroundKind,
+    foregroundStopCount: foregroundKind === "gradient" ? foregroundStops?.length : undefined,
+    foregroundStops,
+    backgroundKind,
+    backgroundStopCount: backgroundKind === "gradient" ? backgroundStops?.length : undefined,
+    backgroundStops,
+    suggestion,
+  };
+}
+
+function readNodePaint(
+  node: BaseNode,
+  key: "fills" | "strokes"
+): Paint | readonly Paint[] | typeof figma.mixed | null {
+  if (!(key in node)) return null;
+  try {
+    return (
+      node as unknown as Record<
+        string,
+        Paint | readonly Paint[] | typeof figma.mixed
+      >
+    )[key];
+  } catch {
+    return null;
+  }
+}
+
+function readNodeChildren(node: BaseNode): readonly BaseNode[] {
+  if (!("children" in node)) return [];
+  try {
+    return node.children as readonly BaseNode[];
+  } catch {
+    return [];
+  }
+}
+
+function readParent(node: BaseNode): BaseNode | null {
+  if (!("parent" in node)) return null;
+  try {
+    return node.parent;
+  } catch {
+    return null;
+  }
+}
+
+function readNodeOpacity(node: BaseNode): number {
+  if (!("opacity" in node)) return 1;
+  try {
+    const value = (node as unknown as { opacity?: number }).opacity;
+    return clampAlpha(value ?? 1);
+  } catch {
+    return 1;
+  }
+}
+
+function resolveOpacityChain(node: BaseNode): number {
+  let opacity = readNodeOpacity(node);
+  let parent: BaseNode | null = readParent(node);
+  while (parent) {
+    opacity *= readNodeOpacity(parent);
+    parent = readParent(parent);
+  }
+  return clampAlpha(opacity);
+}
+
+function serializeGradientStops(
+  samples: RgbaSample[],
+  opacityFactor = 1
+): Array<{ position: number; color: string; alpha: number }> {
+  return samples
+    .map((sample, index) => ({
+      position:
+        typeof sample.position === "number"
+          ? sample.position
+          : index / Math.max(samples.length - 1, 1),
+      color: rgbToHex(sample.color),
+      alpha: clampAlpha(sample.alpha * opacityFactor),
+    }))
+    .sort((left, right) => left.position - right.position);
+}
+
+function resolveForegroundPaint(node: SceneNode): PaintResolution {
+  const fillPaint = readNodePaint(node, "fills");
+  const fillResolution = resolvePaint(fillPaint);
+  if (fillResolution.status === "ok") return fillResolution;
+  if (
+    fillResolution.status === "image" ||
+    fillResolution.status === "mixed" ||
+    fillResolution.status === "multi"
+  ) {
+    return fillResolution;
+  }
+
+  const strokePaint = readNodePaint(node, "strokes");
+  return resolvePaint(strokePaint);
+}
+
+type BackgroundSource =
+  | {
+      kind: "ok";
+      resolution: Extract<PaintResolution, { status: "ok" }>;
+      node: BaseNode | null;
+    }
+  | {
+      kind: "unsupported";
+      reason: ContrastUnsupportedReason;
+    };
+
+function resolveBackgroundPaint(
+  node: SceneNode,
+  foregroundSamples: RgbaSample[]
+): BackgroundSource {
+  const inspectCandidate = (
+    candidate: Paint | readonly Paint[] | typeof figma.mixed | null,
+    sourceNode: BaseNode | null
+  ): BackgroundSource | null => {
+    const resolution = resolvePaint(candidate);
+    if (resolution.status === "none") return null;
+    if (resolution.status === "ok") {
+      if (samplesEquivalent(resolution.samples, foregroundSamples)) {
+        return null;
+      }
+      return {
+        kind: "ok",
+        resolution,
+        node: sourceNode,
+      };
+    }
+    return {
+      kind: "unsupported",
+      reason: toUnsupportedReason(resolution.status),
+    };
+  };
+
+  if (node.type === "FRAME") {
+    const ownBackground = inspectCandidate(readNodePaint(node, "fills"), node);
+    if (ownBackground) return ownBackground;
+  }
+
+  let parent: BaseNode | null = readParent(node);
+  while (parent) {
+    const parentBackground = inspectCandidate(readNodePaint(parent, "fills"), parent);
+    if (parentBackground) return parentBackground;
+    parent = readParent(parent);
+  }
+
+  if ("backgrounds" in figma.currentPage) {
+    const pageBackground = inspectCandidate(figma.currentPage.backgrounds, null);
+    if (pageBackground) return pageBackground;
+  }
+
+  return {
+    kind: "unsupported",
+    reason: "no-pair",
+  };
+}
+
+function hasImagePaintWithin(node: BaseNode, depth = 0): boolean {
+  const fills = resolvePaint(readNodePaint(node, "fills"));
+  if (fills.status === "image") return true;
+  const strokes = resolvePaint(readNodePaint(node, "strokes"));
+  if (strokes.status === "image") return true;
+  if (depth >= 2) return false;
+  const children = readNodeChildren(node);
+  for (const child of children) {
+    if (hasImagePaintWithin(child, depth + 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveContrastFromNode(node: SceneNode): ContrastResolution {
+  const foregroundResolution = resolveForegroundPaint(node);
+  if (foregroundResolution.status !== "ok") {
+    if (foregroundResolution.status === "none") {
+      return { kind: "unsupported", reason: "no-pair" };
+    }
+    return {
+      kind: "unsupported",
+      reason: toUnsupportedReason(foregroundResolution.status),
+    };
+  }
+
+  const backgroundResolution = resolveBackgroundPaint(
+    node,
+    foregroundResolution.samples
+  );
+  if (backgroundResolution.kind === "unsupported") {
+    return backgroundResolution;
+  }
+
+  const backgroundPaint = backgroundResolution.resolution;
+  if (
+    foregroundResolution.kind === "gradient" &&
+    backgroundPaint.kind === "gradient"
+  ) {
+    return {
+      kind: "unsupported",
+      reason: "two-gradients",
+    };
+  }
+
+  const fallbackWhite: RGB = { r: 1, g: 1, b: 1 };
+  const pageBackground =
+    "backgrounds" in figma.currentPage
+      ? resolvePaint(figma.currentPage.backgrounds)
+      : { status: "none" as const };
+  const baseBackground =
+    pageBackground.status === "ok" && pageBackground.samples.length > 0
+      ? pageBackground.samples[0].color
+      : fallbackWhite;
+
+  const foregroundOpacityFactor = resolveOpacityChain(node);
+  const backgroundOpacityFactor = backgroundResolution.node
+    ? resolveOpacityChain(backgroundResolution.node)
+    : 1;
+
+  let bestRatio = Number.POSITIVE_INFINITY;
+  let bestForeground: RGB = fallbackWhite;
+  let bestBackground: RGB = fallbackWhite;
+
+  for (const bgSample of backgroundPaint.samples) {
+    const effectiveBackground = blendOver(
+      bgSample.color,
+      baseBackground,
+      bgSample.alpha * backgroundOpacityFactor
+    );
+
+    for (const fgSample of foregroundResolution.samples) {
+      const effectiveForeground = blendOver(
+        fgSample.color,
+        effectiveBackground,
+        fgSample.alpha * foregroundOpacityFactor
+      );
+      const candidateRatio = getContrastRatio(effectiveForeground, effectiveBackground);
+      if (candidateRatio < bestRatio) {
+        bestRatio = candidateRatio;
+        bestForeground = effectiveForeground;
+        bestBackground = effectiveBackground;
+      }
+    }
+  }
+
+  if (!Number.isFinite(bestRatio)) {
+    return { kind: "unsupported", reason: "no-pair" };
+  }
+
+  const foregroundStops =
+    foregroundResolution.kind === "gradient"
+      ? serializeGradientStops(foregroundResolution.samples, foregroundOpacityFactor)
+      : undefined;
+  const backgroundStops =
+    backgroundPaint.kind === "gradient"
+      ? serializeGradientStops(backgroundPaint.samples, backgroundOpacityFactor)
+      : undefined;
+  // Allow swap preview for all supported contrast pairs, including gradient cases.
+  // The ratio is symmetric and this unlocks useful "what-if" visual checks.
+  const swappable = true;
+
+  return {
+    kind: "result",
+    result: buildContrastResult(
+      bestRatio,
+      bestForeground,
+      bestBackground,
+      foregroundResolution.kind,
+      backgroundPaint.kind,
+      swappable,
+      foregroundStops,
+      backgroundStops
+    ),
+  };
+}
+
 /**
  * Hook that provides contrast checking functionality.
  */
 export function useContrastChecker() {
   const [contrastResult, setContrastResult] =
     useSyncedState<ContrastResult | null>("contrastResult", null);
-  const [isChecking, setIsChecking] = useSyncedState("isChecking", false);
+  const [contrastNotice, setContrastNotice] = useSyncedState<string | null>(
+    "contrastNotice",
+    null
+  );
+  const [contrastSwapped, setContrastSwapped] = useSyncedState<boolean>(
+    "contrastSwapped",
+    false
+  );
 
   /**
    * Checks contrast for currently selected elements.
@@ -96,59 +584,38 @@ export function useContrastChecker() {
   const checkSelection = () => {
     try {
       const selection = figma.currentPage.selection;
-      if (selection.length === 0) {
+      const node =
+        selection.find((selectedNode) => selectedNode.type !== "WIDGET") ?? null;
+      if (!node) {
         setContrastResult(null);
+        setContrastNotice(getContrastNotice("no-selection"));
+        setContrastSwapped(false);
         return;
       }
 
-      // Get first selected node
-      const node = selection[0];
-
-      // Try to extract foreground and background colors
-      let foregroundColor: RGB | null = null;
-      let backgroundColor: RGB | null = null;
-
-      // Check if node has fills (text or shape)
-      if ("fills" in node) {
-        foregroundColor = extractColor(node.fills);
-      }
-
-      // Try to find background from parent or node itself
-      if ("parent" in node && node.parent && "fills" in node.parent) {
-        backgroundColor = extractColor(node.parent.fills);
-      } else if ("fills" in node && node.type === "FRAME") {
-        backgroundColor = extractColor(node.fills);
-      }
-
-      // If we have both colors, calculate contrast
-      if (foregroundColor && backgroundColor) {
-        const ratio = getContrastRatio(foregroundColor, backgroundColor);
-        const passesAA = ratio >= 4.5;
-        const passesAAA = ratio >= 7.0;
-
-        let suggestion = "";
-        if (!passesAA) {
-          suggestion =
-            "Contrast too low. Increase difference between colors to meet WCAG AA (4.5:1).";
-        } else if (!passesAAA) {
-          suggestion =
-            "Meets AA standard. Consider increasing contrast for AAA (7:1) compliance.";
-        }
-
-        setContrastResult({
-          ratio: Math.round(ratio * 100) / 100,
-          passesAA,
-          passesAAA,
-          foreground: rgbToHex(foregroundColor),
-          background: rgbToHex(backgroundColor),
-          suggestion,
-        });
-      } else {
+      if (hasImagePaintWithin(node)) {
         setContrastResult(null);
+        setContrastNotice(getContrastNotice("image"));
+        setContrastSwapped(false);
+        return;
       }
-    } catch (error) {
-      console.error("Error checking contrast:", error);
+
+      const resolution = resolveContrastFromNode(node);
+      if (resolution.kind === "result") {
+        setContrastResult(resolution.result);
+        setContrastNotice(null);
+        setContrastSwapped(false);
+        return;
+      }
+
       setContrastResult(null);
+      setContrastNotice(getContrastNotice(resolution.reason));
+      setContrastSwapped(false);
+    } catch {
+      // Ignore stale-node read errors from deleted or detached instance layers.
+      setContrastResult(null);
+      setContrastNotice(getContrastNotice("stale-selection"));
+      setContrastSwapped(false);
     }
   };
 
@@ -157,14 +624,20 @@ export function useContrastChecker() {
    */
   const clearResult = () => {
     setContrastResult(null);
-    setIsChecking(false);
+    setContrastNotice(null);
+    setContrastSwapped(false);
+  };
+
+  const toggleContrastSwap = () => {
+    setContrastSwapped(!contrastSwapped);
   };
 
   return {
     contrastResult,
-    isChecking,
+    contrastNotice,
+    contrastSwapped,
     checkSelection,
     clearResult,
-    setIsChecking,
+    toggleContrastSwap,
   };
 }

--- a/widget-src/hooks/useQuickCopy.ts
+++ b/widget-src/hooks/useQuickCopy.ts
@@ -11,6 +11,8 @@ import { parseInlineMarkup, segmentsToMarkdown } from "logic/inlineMarkup";
 import { getWcagCriteriaCodesByLevel } from "logic/wcag";
 
 const WCAG_LEVEL_ORDER = ["A", "AA", "AAA"] as const;
+const TASK_CONTINUATION_INDENT = "  ";
+const TASK_CONTINUATION_WIDTH = 96;
 
 function normalizeLevel(value: string | null | undefined) {
   if (!value) return null;
@@ -23,6 +25,65 @@ function normalizeLevel(value: string | null | undefined) {
 function parseWcagCode(wcag: string | undefined) {
   const match = wcag?.match(/(\d+\.\d+\.\d+)/);
   return match ? match[1] : null;
+}
+
+function wrapWordsToWidth(text: string, maxWidth: number): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [];
+
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    if (!current) {
+      current = word;
+      continue;
+    }
+    if (current.length + 1 + word.length <= maxWidth) {
+      current = `${current} ${word}`;
+      continue;
+    }
+    lines.push(current);
+    current = word;
+  }
+
+  if (current) {
+    lines.push(current);
+  }
+  return lines;
+}
+
+function formatTaskContinuation(markdownText: string): string {
+  const normalized = markdownText.replace(/\r\n?/g, "\n").trim();
+  if (!normalized) return "";
+
+  const maxWidth = Math.max(
+    24,
+    TASK_CONTINUATION_WIDTH - TASK_CONTINUATION_INDENT.length
+  );
+  const paragraphs = normalized
+    .split(/\n\s*\n/g)
+    .map((paragraph) =>
+      paragraph
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .join(" ")
+    )
+    .filter(Boolean);
+
+  const lines: string[] = [];
+  paragraphs.forEach((paragraph, index) => {
+    if (index > 0) {
+      lines.push(TASK_CONTINUATION_INDENT);
+    }
+    const wrapped = wrapWordsToWidth(paragraph, maxWidth);
+    wrapped.forEach((line) => {
+      lines.push(`${TASK_CONTINUATION_INDENT}${line}`);
+    });
+  });
+
+  return lines.length > 0 ? `${lines.join("\n")}\n` : "";
 }
 
 /**
@@ -71,14 +132,14 @@ export function useQuickCopy() {
     markdown += `**Progress**: ${completed}/${section.items.length} complete\n\n`;
 
     section.items.forEach((item) => {
-      const status = taskCompletion[item.id] ? "✅" : "⬜";
-      markdown += `${status} ${toMarkdown(item.text)}`;
+      const status = taskCompletion[item.id] ? "[x]" : "[ ]";
+      markdown += `- ${status} ${toMarkdown(item.text)}`;
       if (item.wcag) {
         markdown += ` _(${item.wcag})_`;
       }
       markdown += "\n";
       if (item.longDescription) {
-        markdown += `   ${toMarkdown(item.longDescription)}\n`;
+        markdown += formatTaskContinuation(toMarkdown(item.longDescription));
       }
       markdown += "\n";
     });

--- a/widget-src/hooks/useUserPreferences.ts
+++ b/widget-src/hooks/useUserPreferences.ts
@@ -1,16 +1,27 @@
 const { widget } = figma;
-const { useSyncedMap, useSyncedState, useEffect } = widget;
+const { useSyncedMap, useWidgetId } = widget;
 
 import { defaultTheme } from "design-system";
 import { templates, type TemplateType } from "data/templates";
 import { normalizeHexColor } from "shared/hexColor";
+import {
+  buildPreferenceMapKey,
+  resolveWidgetScope,
+} from "shared/preferenceNamespace";
+
+export type ContrastInspectorPair =
+  | "progress-on-panel"
+  | "progress-on-header"
+  | "text-primary-on-panel";
 
 export type UserPreferences = {
   hideCompleted: boolean;
-  theme: "light" | "dark" | "system";
+  theme: "light" | "dark";
   language: "en" | "es";
   selectedTemplate: TemplateType;
   accentColor: string;
+  showContrastInspector: boolean;
+  contrastPair: ContrastInspectorPair;
 };
 
 const DEFAULT_PREFERENCES: UserPreferences = {
@@ -19,59 +30,67 @@ const DEFAULT_PREFERENCES: UserPreferences = {
   language: "en",
   selectedTemplate: "all",
   accentColor: defaultTheme.lightTheme.progressFill,
+  showContrastInspector: false,
+  contrastPair: "progress-on-panel",
 };
 
-const VALID_THEMES = new Set<UserPreferences["theme"]>([
-  "light",
-  "dark",
-  "system",
-]);
+const VALID_THEMES = new Set<UserPreferences["theme"]>(["light", "dark"]);
 const VALID_LANGUAGES = new Set<UserPreferences["language"]>(["en", "es"]);
 const VALID_TEMPLATES = new Set<TemplateType>(
-  templates.map((template) => template.id)
+  templates.map((template) => template.id),
 );
+const VALID_CONTRAST_PAIRS = new Set<ContrastInspectorPair>([
+  "progress-on-panel",
+  "progress-on-header",
+  "text-primary-on-panel",
+]);
 
-function normalizePreferences(value: UserPreferences): UserPreferences {
+function normalizePreferences(
+  value: Partial<UserPreferences> & { theme?: string },
+): UserPreferences {
   const accentColor =
     normalizeHexColor(value.accentColor) ?? DEFAULT_PREFERENCES.accentColor;
+  const themeValue =
+    typeof value.theme === "string" &&
+    VALID_THEMES.has(value.theme as UserPreferences["theme"])
+      ? (value.theme as UserPreferences["theme"])
+      : DEFAULT_PREFERENCES.theme;
+  const languageValue =
+    typeof value.language === "string" &&
+    VALID_LANGUAGES.has(value.language as UserPreferences["language"])
+      ? (value.language as UserPreferences["language"])
+      : DEFAULT_PREFERENCES.language;
+  const templateValue =
+    typeof value.selectedTemplate === "string" &&
+    VALID_TEMPLATES.has(value.selectedTemplate as TemplateType)
+      ? (value.selectedTemplate as TemplateType)
+      : DEFAULT_PREFERENCES.selectedTemplate;
+  const contrastPairValue =
+    typeof value.contrastPair === "string" &&
+    VALID_CONTRAST_PAIRS.has(value.contrastPair as ContrastInspectorPair)
+      ? (value.contrastPair as ContrastInspectorPair)
+      : DEFAULT_PREFERENCES.contrastPair;
   return {
     hideCompleted: Boolean(value.hideCompleted),
-    theme: VALID_THEMES.has(value.theme) ? value.theme : DEFAULT_PREFERENCES.theme,
-    language: VALID_LANGUAGES.has(value.language)
-      ? value.language
-      : DEFAULT_PREFERENCES.language,
-    selectedTemplate: VALID_TEMPLATES.has(value.selectedTemplate)
-      ? value.selectedTemplate
-      : DEFAULT_PREFERENCES.selectedTemplate,
+    theme: themeValue,
+    language: languageValue,
+    selectedTemplate: templateValue,
     accentColor,
+    showContrastInspector: Boolean(value.showContrastInspector),
+    contrastPair: contrastPairValue,
   };
 }
 
 export function useUserPreferences() {
   const preferencesMap = useSyncedMap<UserPreferences>("userPreferences");
-  const [, setRevision] = useSyncedState("userPreferencesRevision", 0);
-  const [userKey, setUserKey] = useSyncedState<string>(
-    "userPreferencesKey",
-    "user:default"
-  );
-
-  useEffect(() => {
-    const userId = figma.currentUser?.id;
-    if (!userId) return;
-    const nextKey = `user:${userId}`;
-    if (userKey === nextKey) return;
-    const currentPrefs = preferencesMap.get(userKey);
-    const nextPrefs = preferencesMap.get(nextKey);
-    if (!nextPrefs && currentPrefs) {
-      preferencesMap.set(nextKey, currentPrefs);
-    }
-    setUserKey(nextKey);
-    setRevision((value) => value + 1);
-  });
+  const widgetId = useWidgetId();
+  const widgetScope = resolveWidgetScope(widgetId ?? null);
+  const userScope = "shared";
+  const userKey = buildPreferenceMapKey(userScope, widgetScope);
 
   const stored = preferencesMap.get(userKey);
   const preferences = normalizePreferences(
-    stored ? { ...DEFAULT_PREFERENCES, ...stored } : DEFAULT_PREFERENCES
+    stored ? { ...DEFAULT_PREFERENCES, ...stored } : DEFAULT_PREFERENCES,
   );
 
   const setPreferences = (next: Partial<UserPreferences>) => {
@@ -81,7 +100,6 @@ export function useUserPreferences() {
       ...next,
     };
     preferencesMap.set(userKey, normalizePreferences(merged));
-    setRevision((value) => value + 1);
   };
 
   return {

--- a/widget-src/i18n/index.ts
+++ b/widget-src/i18n/index.ts
@@ -18,6 +18,19 @@ export type Messages = {
   themeLabel: string;
   brandThemeLabel: string;
   languageLabel: string;
+  contrastInspectorToggle: string;
+  contrastPairLabel: string;
+  contrastCheckSelection: string;
+  contrastClearSelection: string;
+  contrastInspectorHint: string;
+  contrastNoData: string;
+  contrastRunCheck: string;
+  contrastSwap: string;
+  contrastSwapSolidOnly: string;
+  contrastClear: string;
+  contrastLargeTextOnly: string;
+  contrastTextLabel: string;
+  contrastBackgroundLabel: string;
   layoutLabel: string;
   noResults: string;
   quickCopy: string;
@@ -34,6 +47,11 @@ export type Messages = {
     mobileApp: { name: string; description: string };
     quickAudit: { name: string; description: string };
     formsHeavy: { name: string; description: string };
+  };
+  contrastPairs: {
+    progressOnPanel: string;
+    progressOnHeader: string;
+    textPrimaryOnPanel: string;
   };
 };
 
@@ -55,6 +73,19 @@ const en: Messages = {
   themeLabel: "Theme",
   brandThemeLabel: "Accent color",
   languageLabel: "Language",
+  contrastInspectorToggle: "Contrast",
+  contrastPairLabel: "Contrast Pair",
+  contrastCheckSelection: "Check selected layer contrast",
+  contrastClearSelection: "Clear contrast result",
+  contrastInspectorHint: "Select a layer, then Check.",
+  contrastNoData: "No result yet",
+  contrastRunCheck: "Check",
+  contrastSwap: "Swap",
+  contrastSwapSolidOnly: "Swap works only for solid pairs.",
+  contrastClear: "Clear",
+  contrastLargeTextOnly: "Large text only",
+  contrastTextLabel: "Text",
+  contrastBackgroundLabel: "Background",
   layoutLabel: "Layout",
   noResults: "No items found",
   quickCopy: "Export Format:",
@@ -90,6 +121,11 @@ const en: Messages = {
       description: "Forms and data entry focused",
     },
   },
+  contrastPairs: {
+    progressOnPanel: "Progress fill on panel background",
+    progressOnHeader: "Progress fill on header background",
+    textPrimaryOnPanel: "Primary text on panel background",
+  },
 };
 
 const es: Messages = {
@@ -110,6 +146,19 @@ const es: Messages = {
   themeLabel: "Tema",
   brandThemeLabel: "Color de acento",
   languageLabel: "Idioma",
+  contrastInspectorToggle: "Contraste",
+  contrastPairLabel: "Par de contraste",
+  contrastCheckSelection: "Comprobar contraste de capa seleccionada",
+  contrastClearSelection: "Limpiar resultado de contraste",
+  contrastInspectorHint: "Selecciona una capa y luego pulsa Comprobar.",
+  contrastNoData: "Sin resultado",
+  contrastRunCheck: "Comprobar",
+  contrastSwap: "Intercambiar",
+  contrastSwapSolidOnly: "Intercambiar solo funciona con pares sólidos.",
+  contrastClear: "Limpiar",
+  contrastLargeTextOnly: "Solo texto grande",
+  contrastTextLabel: "Texto",
+  contrastBackgroundLabel: "Fondo",
   layoutLabel: "Diseño",
   noResults: "No se encontraron elementos",
   quickCopy: "Formato de Exportación:",
@@ -144,6 +193,11 @@ const es: Messages = {
       name: "Formularios Pesados",
       description: "Enfocado en formularios y entrada de datos",
     },
+  },
+  contrastPairs: {
+    progressOnPanel: "Relleno de progreso sobre fondo del panel",
+    progressOnHeader: "Relleno de progreso sobre fondo del encabezado",
+    textPrimaryOnPanel: "Texto principal sobre fondo del panel",
   },
 };
 

--- a/widget-src/shared/contrastMessages.ts
+++ b/widget-src/shared/contrastMessages.ts
@@ -1,0 +1,22 @@
+export type ContrastUnsupportedReason =
+  | "image"
+  | "two-gradients"
+  | "mixed-fills"
+  | "multi-fills"
+  | "no-pair"
+  | "no-selection"
+  | "stale-selection";
+
+const CONTRAST_NOTICES: Record<ContrastUnsupportedReason, string> = {
+  image: "Image not supported.",
+  "two-gradients": "Two gradients not supported.",
+  "mixed-fills": "Mixed fill not supported.",
+  "multi-fills": "Multiple fills not supported.",
+  "no-pair": "No contrast pair found.",
+  "no-selection": "No layer selected.",
+  "stale-selection": "Selection changed. Check again.",
+};
+
+export function getContrastNotice(reason: ContrastUnsupportedReason): string {
+  return CONTRAST_NOTICES[reason];
+}

--- a/widget-src/shared/preferenceNamespace.ts
+++ b/widget-src/shared/preferenceNamespace.ts
@@ -1,0 +1,72 @@
+export type PreferenceNamespaceInput = {
+  userId?: string | null;
+  sessionId?: number | null;
+  widgetId?: string | null;
+};
+
+export type PreferenceNamespace = {
+  userScope: string;
+  widgetScope: string;
+  mapKey: string;
+  legacyKeys: string[];
+};
+
+function hasContent(value: string | null | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function encodeScopeValue(value: string): string {
+  return encodeURIComponent(value.trim());
+}
+
+export function resolveUserScope(
+  userId?: string | null,
+  sessionId?: number | null
+): string {
+  if (hasContent(userId)) {
+    return `id:${encodeScopeValue(userId)}`;
+  }
+  if (sessionId !== null && sessionId !== undefined) {
+    return `session:${sessionId}`;
+  }
+  return "anonymous";
+}
+
+export function resolveWidgetScope(widgetId?: string | null): string {
+  return hasContent(widgetId) ? encodeScopeValue(widgetId) : "unknown";
+}
+
+export function buildPreferenceMapKey(
+  userScope: string,
+  widgetScope: string
+): string {
+  return `prefs:user:${userScope}:widget:${widgetScope}`;
+}
+
+export function resolvePreferenceNamespace({
+  userId,
+  sessionId,
+  widgetId,
+}: PreferenceNamespaceInput): PreferenceNamespace {
+  const userScope = resolveUserScope(userId, sessionId);
+  const widgetScope = resolveWidgetScope(widgetId);
+  const mapKey = buildPreferenceMapKey(userScope, widgetScope);
+  const legacyKeys: string[] = [];
+
+  if (hasContent(userId)) {
+    legacyKeys.push(`user:${userId}`);
+  }
+
+  if (sessionId !== null && sessionId !== undefined) {
+    legacyKeys.push(`user:session:${sessionId}`);
+  }
+
+  legacyKeys.push("user:default");
+
+  return {
+    userScope,
+    widgetScope,
+    mapKey,
+    legacyKeys,
+  };
+}

--- a/widget-src/types/components.ts
+++ b/widget-src/types/components.ts
@@ -100,8 +100,6 @@ export interface ChecklistProps {
   total: number;
   /** Number of completed tasks. */
   completed: number;
-  /** Whether to use dark mode styling. */
-  isDarkMode?: boolean;
   /** Section ids that should show item descriptions. */
   showItemDescriptionsForSectionIds?: string[];
   /** Current user preferences. */


### PR DESCRIPTION
- adds an in-widget contrast inspector with gradient-aware sampling, swap support, and unsupported-state notices
- scopes user preferences by widget namespace and simplifies theme selection to light/dark
- improves avatar overflow handling and markdown export task-list formatting
- expands property-menu grouping, i18n labels, and hardening checks
