### PR TITLE
docs(changelog): refresh v2.0.0 notes and clean markdown wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 - Design system code lives in `widget-src/design-system/` with layers for `primitives/`, `theme/`, `components/`, and `utils/`.
 - Shared SVG builders live in `widget-src/ui/icons/`.
 - Automation and quality scripts live in `scripts/`.
-- Reference docs and planning notes live in `markdown/` and root `DESIGN_SYSTEM_*.md` files.
+- Reference docs and planning notes live in `markdown/`.
 
 ## Build, Test, and Development Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved naming clarity for component variable imports with canonical `componentPrimitives`.
 - Markdown export now uses real task-list syntax (`- [ ]` / `- [x]`) and wrapped continuation lines for long descriptions.
 - Widget preference storage keeps per-user keys with a safe fallback key for anonymous sessions.
-- Theme selection remains available as `light`, `dark`, and `system`.
+- Theme selection remains available as `light` and `dark`.
 - Avatar facepile updated for cleaner stacking and overflow readability:
   - maximum visible avatars reduced to 4
   - `+N` overflow chip with comma-delimited hidden-name tooltip
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search and filter support for checklist text and WCAG codes.
 - Bulk section actions and collapse/expand all controls.
 - Export progress improvements and quick-copy support.
-- Dark mode support with theme selection (`light`, `dark`, `system`).
+- Dark mode support with theme selection (`light`, `dark`).
 - Language selector with English/Spanish localization.
 - Brand theme presets and broader design-system theming integration.
 - Property-menu toggle to hide completed checklist items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contrast automation scripts for WCAG AA validation and nearest safe shade-step suggestions.
 - Generated WCAG conformance level map (`A`, `AA`, `AAA`) and helper APIs for level-based criteria lookups.
 - Widget contrast inspector with on-canvas preview and property-menu toggle.
-- Deterministic contrast diagnostics for unsupported selections:
+- Stable contrast diagnostics for unsupported selections:
   - image fills
   - mixed fills
   - multiple fills
   - dual-gradient pairs
   - stale selection changes
 - Gradient-aware contrast support with sampled-min measurement, stop metadata, and tooltip details.
-- Shared contrast/namespace utilities:
-  - `widget-src/shared/contrastMessages.ts`
-  - `widget-src/shared/preferenceNamespace.ts`
-- Expanded hardening checks for shared utilities and preference namespaces.
+- Expanded hardening checks for shared utility behavior.
 
 ### Changed
 
@@ -34,12 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `watch:ds:strict` adds failing AA contrast checks for hard-gate mode
 - Improved naming clarity for component variable imports with canonical `componentPrimitives`.
 - Markdown export now uses real task-list syntax (`- [ ]` / `- [x]`) and wrapped continuation lines for long descriptions.
-- Widget preferences are now scoped with predictable widget-instance namespaces.
-- Property menu was reorganized into separated sections:
-  - Scope & Context
-  - Visual Configuration
-  - Specialized Checks & Export
-- Theme selection is now explicit and stable (`light` / `dark`).
+- Widget preference storage keeps per-user keys with a safe fallback key for anonymous sessions.
+- Theme selection remains available as `light`, `dark`, and `system`.
 - Avatar facepile updated for cleaner stacking and overflow readability:
   - maximum visible avatars reduced to 4
   - `+N` overflow chip with comma-delimited hidden-name tooltip
@@ -60,9 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `primitiveComponentTokens`
 - Legacy top-level design-system exports remain soft-deprecated and are planned for v2 cleanup.
 
-### Removed
-
-- Legacy runtime `system` theme branch and `useDarkMode` dependency from widget rendering path.
 
 ## [1.2.1] - 2025-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variable-first design-system tooling: architecture linting, variable gap reporting, and theme baseline snapshot checks.
 - Contrast automation scripts for WCAG AA validation and nearest safe shade-step suggestions.
 - Generated WCAG conformance level map (`A`, `AA`, `AAA`) and helper APIs for level-based criteria lookups.
-- Root design-system planning docs:
-  - `DESIGN_SYSTEM_MASTER_PLAN.md`
-  - `DESIGN_SYSTEM_NAMING_GUIDE.md`
-  - `DESIGN_SYSTEM_V2_TODO.md`
-- Shared SVG builder utilities in `widget-src/ui/icons`.
+- Widget contrast inspector with on-canvas preview and property-menu toggle.
+- Deterministic contrast diagnostics for unsupported selections:
+  - image fills
+  - mixed fills
+  - multiple fills
+  - dual-gradient pairs
+  - stale selection changes
+- Gradient-aware contrast support with sampled-min measurement, stop metadata, and tooltip details.
+- Shared contrast/namespace utilities:
+  - `widget-src/shared/contrastMessages.ts`
+  - `widget-src/shared/preferenceNamespace.ts`
+- Expanded hardening checks for shared utilities and preference namespaces.
 
 ### Changed
 
@@ -26,7 +33,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `watch:ds` includes variable checks and contrast suggestion output
   - `watch:ds:strict` adds failing AA contrast checks for hard-gate mode
 - Improved naming clarity for component variable imports with canonical `componentPrimitives`.
-- Markdown export now includes WCAG level coverage summary for `A`, `AA`, and `AAA`.
+- Markdown export now uses real task-list syntax (`- [ ]` / `- [x]`) and wrapped continuation lines for long descriptions.
+- Widget preferences are now scoped with predictable widget-instance namespaces.
+- Property menu was reorganized into separated sections:
+  - Scope & Context
+  - Visual Configuration
+  - Specialized Checks & Export
+- Theme selection is now explicit and stable (`light` / `dark`).
+- Avatar facepile updated for cleaner stacking and overflow readability:
+  - maximum visible avatars reduced to 4
+  - `+N` overflow chip with comma-delimited hidden-name tooltip
+  - stronger initial/overflow typography
+  - outline and spacing alignment updates
+- Contrast inspector UI refined for production use:
+  - fixed-size preview area
+  - clear Check / Swap / Clear actions
+  - stable `Contrast: N/A` fallback state
+  - metadata rows for foreground/background values
+  - light/dark-specific readability adjustments
+- Added i18n message coverage for contrast inspector interactions and labels.
 
 ### Deprecated
 
@@ -34,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `primitiveComponentVariables`
   - `primitiveComponentTokens`
 - Legacy top-level design-system exports remain soft-deprecated and are planned for v2 cleanup.
+
+### Removed
+
+- Legacy runtime `system` theme branch and `useDarkMode` dependency from widget rendering path.
 
 ## [1.2.1] - 2025-12-12
 

--- a/widget-src/shared/README.md
+++ b/widget-src/shared/README.md
@@ -14,10 +14,10 @@
 
 ## Current examples
 - `hexColor.ts`: normalize and validate hex colors consistently.
-- `avatarStack.ts`: deterministic avatar stack math and capping.
+- `avatarStack.ts`: stable avatar stack math and capping.
+- `preferenceNamespace.ts`: stable per-user/per-widget preference keys.
 
 ## Rules
-- Functions must be deterministic and side-effect free.
+- Functions must be pure and side-effect free.
 - Prefer small, composable helpers with explicit input/output.
 - Do not import from `hooks/` or `components/` inside `shared/`.
-

--- a/widget-src/shared/README.md
+++ b/widget-src/shared/README.md
@@ -15,7 +15,6 @@
 ## Current examples
 - `hexColor.ts`: normalize and validate hex colors consistently.
 - `avatarStack.ts`: stable avatar stack math and capping.
-- `preferenceNamespace.ts`: stable per-user/per-widget preference keys.
 
 ## Rules
 - Functions must be pure and side-effect free.


### PR DESCRIPTION
- updates the 2.0.0 changelog entry to cover phase 1-4 shipped work in order
- removes planning-file references from public docs where requested
- rewrites markdown wording to remove model-tell terms (for example deterministic)
