### PR TITLE
docs(release): refresh v2.0.0 changelog and readme

### DIFF
--- a/.github/LISTING_ATTRIBUTION_GUIDANCE.md
+++ b/.github/LISTING_ATTRIBUTION_GUIDANCE.md
@@ -12,8 +12,8 @@ This project is open source and community-friendly. To help users get the safest
 ## Project Request
 
 - Please do not publish rebranded or near-identical copies of this widget to Figma Community.
-- If you publish derivative work, keep clear attribution to this project and clearly label it as unofficial.
-- Make differences obvious to users (feature changes, bug fixes, known limitations, and version source).
+- Please do not republish this widget under a different name, branding, or listing.
+- If you fork this repository under the open-source license, do not present it as the official a11y Companion Widget.
 
 ## Why This Matters
 

--- a/.github/LISTING_ATTRIBUTION_GUIDANCE.md
+++ b/.github/LISTING_ATTRIBUTION_GUIDANCE.md
@@ -1,0 +1,56 @@
+# Official Listing and Attribution Guidance
+
+This project is open source and community-friendly. To help users get the safest and most up-to-date experience, please point people to the official a11y Companion Widget listing and repository when sharing the widget.
+
+## Official Sources
+
+- Official Figma Community listing:
+  - https://www.figma.com/community/widget/1509302611418259130
+- Official GitHub repository and releases:
+  - https://github.com/marklearst/a11y-companion-widget
+
+If you publish derivative work, please provide clear attribution and make the differences from the official a11y Companion Widget obvious to users.
+
+## Why This Matters
+
+- Users get timely fixes and accurate release notes from the official source.
+- Community trust improves when attribution is clear.
+- Unofficial copies can include unreviewed changes, regressions, or security issues that this project cannot support.
+
+## If You Find a Confusing Re-Listing
+
+Please share:
+
+- URL of the listing/repository
+- URL of the official a11y Companion Widget source
+- Screenshots of matching UI/version details
+- Date/time discovered
+
+## Report It to This Project
+
+### Open a GitHub Issue
+
+- Use this link:
+  - https://github.com/marklearst/a11y-companion-widget/issues/new
+- Suggested title format:
+  - `[Listing Report] <short summary>`
+- Include:
+  - where you found it
+  - what appears copied or confusing
+  - screenshots and dates
+  - any user-facing risks (bugs, broken behavior, security concerns)
+
+### Contact Email
+
+- If you prefer email or need to share sensitive details:
+  - github@marklearst.com
+
+## Platform Report Channels
+
+### GitHub
+
+- https://support.github.com/
+
+### Figma Community
+
+- https://help.figma.com/

--- a/.github/LISTING_ATTRIBUTION_GUIDANCE.md
+++ b/.github/LISTING_ATTRIBUTION_GUIDANCE.md
@@ -13,7 +13,8 @@ This project is open source and community-friendly. To help users get the safest
 
 - Please do not publish rebranded or near-identical copies of this widget to Figma Community.
 - Please do not republish this widget under a different name, branding, or listing.
-- If you fork this repository under the open-source license, do not present it as the official a11y Companion Widget.
+- Do not create alternate public listings of this widget (or substantially similar copies) in Figma Community.
+- The official listing is the only supported public release from this project.
 
 ## Why This Matters
 

--- a/.github/LISTING_ATTRIBUTION_GUIDANCE.md
+++ b/.github/LISTING_ATTRIBUTION_GUIDANCE.md
@@ -9,7 +9,11 @@ This project is open source and community-friendly. To help users get the safest
 - Official GitHub repository and releases:
   - https://github.com/marklearst/a11y-companion-widget
 
-If you publish derivative work, please provide clear attribution and make the differences from the official a11y Companion Widget obvious to users.
+## Project Request
+
+- Please do not publish rebranded or near-identical copies of this widget to Figma Community.
+- If you publish derivative work, keep clear attribution to this project and clearly label it as unofficial.
+- Make differences obvious to users (feature changes, bug fixes, known limitations, and version source).
 
 ## Why This Matters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Variable-first design-system tooling: architecture linting, variable gap reporting, and theme baseline snapshot checks.
-- Contrast automation scripts for WCAG AA validation and nearest safe shade-step suggestions.
-- Generated WCAG conformance level map (`A`, `AA`, `AAA`) and helper APIs for level-based criteria lookups.
-- Widget contrast inspector with on-canvas preview and property-menu toggle.
-- Stable contrast diagnostics for unsupported selections:
-  - image fills
-  - mixed fills
-  - multiple fills
-  - dual-gradient pairs
-  - stale selection changes
-- Gradient-aware contrast support with sampled-min measurement, stop metadata, and tooltip details.
-- Expanded hardening checks for shared utility behavior.
+- **Phase 1 - Foundation**
+  - Variable-first design-system tooling: architecture linting, variable gap reporting, and theme baseline snapshot checks.
+  - Contrast automation scripts for WCAG AA validation and nearest safe shade-step suggestions.
+  - Generated WCAG conformance level map (`A`, `AA`, `AAA`, `Failed`) and helper APIs for level-based criteria lookups.
+- **Phase 2 - Contrast Hardening**
+  - Runtime accent-step policy for contrast-safe theme resolution in light/dark modes.
+  - Expanded hardening checks for contrast policy, preset matching, and shared utility behavior.
+- **Phase 4 - Widget UX Upgrades**
+  - Widget contrast inspector with on-canvas preview and property-menu toggle.
+  - Unsupported-selection diagnostics for:
+    - image fills
+    - mixed fills
+    - multiple fills
+    - dual-gradient pairs
+    - stale selection changes
+  - Gradient-aware contrast support with sampled-min measurement, stop metadata, and tooltip details.
+  - AvatarStack activity tracking from real checklist interactions (item toggle and section bulk action).
 
 ### Changed
 
@@ -31,8 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `watch:ds:strict` adds failing AA contrast checks for hard-gate mode
 - Improved naming clarity for component variable imports with canonical `componentPrimitives`.
 - Markdown export now uses real task-list syntax (`- [ ]` / `- [x]`) and wrapped continuation lines for long descriptions.
-- Widget preference storage keeps per-user keys with a safe fallback key for anonymous sessions.
-- Theme selection remains available as `light` and `dark`.
+- Widget preference storage now uses shared widget-instance namespace keys (`prefs:user:shared:widget:<widgetId>`).
+- Property menu was reorganized into clearer sections:
+  - Scope & Context
+  - Visual Configuration
+  - Specialized Checks & Export
+- Theme selection is explicit `light` / `dark`.
 - Avatar facepile updated for cleaner stacking and overflow readability:
   - maximum visible avatars reduced to 4
   - `+N` overflow chip with comma-delimited hidden-name tooltip
@@ -46,13 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - light/dark-specific readability adjustments
 - Added i18n message coverage for contrast inspector interactions and labels.
 
-### Deprecated
+### Removed
 
 - Legacy primitive variable aliases:
   - `primitiveComponentVariables`
   - `primitiveComponentTokens`
-- Legacy top-level design-system exports remain soft-deprecated and are planned for v2 cleanup.
-
+- Runtime `system` theme option from widget preferences and property-menu theme controls.
 
 ## [1.2.1] - 2025-12-12
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ For security-related reports, use the repository security policy:
 - [Listing and Attribution Guidance](.github/LISTING_ATTRIBUTION_GUIDANCE.md)
 
 This project is open source. Please use the official widget listing/repository for the safest and most up-to-date version. Unofficial copies may include unreviewed changes, security issues, or regressions and are not supported by this project.
+Please do not publish rebranded near-identical copies in Figma Community. If you publish derivative work, keep attribution and clearly label it as unofficial.
 
 ## 🤔 Why use this widget?
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Built and maintained by Mark Learst.
 
-![License](https://img.shields.io/github/license/marklearst/a11y-companion-widget)
-![GitHub last commit](https://img.shields.io/github/last-commit/marklearst/a11y-companion-widget)
-![GitHub issues](https://img.shields.io/github/issues/marklearst/a11y-companion-widget)
-[![Figma Community](https://img.shields.io/badge/Figma%20Widget-Open%20in%20Figma-blue?logo=figma)](https://www.figma.com/community/widget/1509302611418259130)
+![License](https://img.shields.io/github/license/marklearst/a11y-companion-widget?style=flat-square)
+![GitHub last commit](https://img.shields.io/github/last-commit/marklearst/a11y-companion-widget?style=flat-square)
+![GitHub issues](https://img.shields.io/github/issues/marklearst/a11y-companion-widget?style=flat-square)
+[![Figma Community](https://img.shields.io/badge/Figma%20Widget-Open%20in%20Figma-blue?style=flat-square&logo=figma)](https://www.figma.com/community/widget/1509302611418259130)
 
 A modern, open-source Figma widget that brings the [A11Y Project Checklist](https://www.a11yproject.com/checklist/) directly into your design workflow. Use this widget to check your designs, content, and code for accessibility and WCAG compliance, collaboratively with your team.
 
@@ -26,28 +26,38 @@ Based on the authoritative [A11Y Project Checklist](https://www.a11yproject.com/
 
 ## ✨ Features
 
-### Core Features
+### Core
 
 - Full A11Y Project checklist, organized by section
-- Each item includes a WCAG reference and a detailed explanation
-- Collapsible sections for easy navigation
-- Progress tracking per section and overall
-- Accessible custom checkboxes
-- WCAG references and detailed explanations
+- Per-section and overall progress tracking
+- WCAG references and detailed guidance per checklist item
+- Search and filter across checklist text and WCAG codes
+- Bulk section actions (check all / uncheck all)
+- Section collapse/expand for faster navigation
+- Markdown export with real task-list syntax (`- [ ]`, `- [x]`)
+- WCAG Level Coverage summary in markdown export (`A`, `AA`, `AAA`)
+- Works in both Figma Design and FigJam
 
-### New in v1.2.0 🎉
+### New in v2.0.0
 
-- **🔍 Search & Filter** - Quickly find checklist items by text or WCAG code
-- **⚡ Bulk Actions** - Mark all items in a section complete/incomplete with one click
-- **📦 Collapse/Expand All** - Quickly navigate large checklists
-- **💾 Export Progress** - Export your progress as JSON for backup or sharing
-- **🌙 Dark Mode** - Full dark mode support with system preference detection
-- **🌍 Localization** - English and Spanish language support
-- **🎨 Enhanced UI** - Improved visual hierarchy and user experience
-
----
-
-**Note:** Collaborative avatars (facepile) for team check-offs were removed in v1.1.0 for a simpler interface and less UI noise, based on overwhelming user feedback. Avatars could be reset by resetting widget state. This feature may return in the future with a toggle to enable or disable it.
+- **Phase 1 - Foundation**
+  - Variable-first design-system guardrails and baseline checks
+  - WCAG contrast automation scripts and watch modes for fast/strict validation
+  - WCAG level map generation and validation tooling
+- **Phase 2 - Contrast Hardening**
+  - Runtime contrast-safe accent resolution for themed UI states
+  - Stronger AA/AAA reliability checks in scripts and hardening tests
+- **Phase 3 - Deprecation Cleanup**
+  - Canonical variable imports and removal of legacy alias usage across runtime modules
+  - Cleaner design-system exports and fewer compatibility shims
+- **Phase 4 - Widget UX Upgrades**
+  - Contrast Inspector with on-canvas preview and property-menu toggle
+  - Contrast status output for `AAA`, `AA`, `A` (large text only), and `Failed`
+  - Gradient-aware contrast checks with sampled-min reporting
+  - Clear unsupported-state messaging (image, mixed fills, dual gradients, stale selection)
+  - AvatarStack activity tracking from real check/uncheck interactions
+  - Improved avatar overflow handling with `+N` summary and readable tooltip names
+  - Theme selection simplified to explicit `light` / `dark`
 
 ## ▶️ How to Use
 
@@ -59,15 +69,71 @@ Based on the authoritative [A11Y Project Checklist](https://www.a11yproject.com/
 6. Click the **collapse/expand** button (▲/▼) to quickly navigate sections.
 7. Hover over checklist items for WCAG references and detailed explanations.
 8. Use the **property menu** to:
-   - Hide completed items
+   - Change language (English/Espanol)
+   - Change checklist template
    - Switch between light/dark themes
-   - Switch between brand themes (Default, Indigo, Emerald, Rose, Slate, Cyan)
-   - Change language (English/Español)
-   - Export your progress as JSON
+   - Switch accent color themes (Default, Indigo, Emerald, Rose, Slate, Cyan)
+   - Toggle Contrast Inspector
+   - Export checklist progress to Markdown
+
+## 🔬 Contrast Inspector
+
+1. Enable **Contrast Inspector** from the property menu.
+2. Select a layer on canvas.
+3. Press **Check** in the inspector row.
+4. Review:
+   - preview sample
+   - ratio and grade
+   - foreground/background metadata
+5. Use **Swap** to preview reversed foreground/background contrast where supported.
+6. Use **Clear** to reset the current inspector result.
+
+The inspector supports solid and single-gradient scenarios. Unsupported combinations are reported with explicit status messages.
+
+## ⚙️ For Builders
+
+Key local commands:
+
+- `pnpm run build` - bundle widget code to `dist/code.js`
+- `pnpm run watch` - rebuild on file changes
+- `pnpm run lint` - ESLint plus design-system architecture checks
+- `pnpm run tsc` - TypeScript checks (`--noEmit`)
+- `pnpm run check:contrast` - AA contrast checks for theme combinations
+- `pnpm run check:contrast:suggest` - nearest safe shade-step suggestions
+- `pnpm run theme:baseline:check` - compare theme output to baseline snapshot
+- `pnpm run test:hardening` - hardening regressions for shared/widget behavior
 
 ## 🗺️ Roadmap
 
 Public roadmap updates are published with release notes in [`CHANGELOG.md`](CHANGELOG.md).
+
+## 🐞 Report Issues
+
+Found a bug or regression? Open an issue here:
+
+- [GitHub Issues](https://github.com/marklearst/a11y-companion-widget/issues)
+
+Please include:
+
+- Figma or FigJam context
+- Steps to reproduce
+- Expected vs actual behavior
+- Screenshots (if UI-related)
+- Environment details (OS/Figma desktop version)
+
+## 🔐 Security
+
+For security-related reports, use the repository security policy:
+
+- [Security Policy](.github/SECURITY.md)
+
+## 🧭 Support and Project Notes
+
+- [Support](.github/SUPPORT.md)
+- [Third-Party Notices](THIRD_PARTY_NOTICES.md)
+- [Listing and Attribution Guidance](.github/LISTING_ATTRIBUTION_GUIDANCE.md)
+
+This project is open source. Please use the official widget listing/repository for the safest and most up-to-date version. Unofficial copies may include unreviewed changes, security issues, or regressions and are not supported by this project.
 
 ## 🤔 Why use this widget?
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ For security-related reports, use the repository security policy:
 - [Listing and Attribution Guidance](.github/LISTING_ATTRIBUTION_GUIDANCE.md)
 
 This project is open source. Please use the official widget listing/repository for the safest and most up-to-date version. Unofficial copies may include unreviewed changes, security issues, or regressions and are not supported by this project.
-Please do not publish rebranded near-identical copies in Figma Community. If you publish derivative work, keep attribution and clearly label it as unofficial.
+Please do not republish this widget under a different name or listing in Figma Community.
 
 ## 🤔 Why use this widget?
 


### PR DESCRIPTION
- align 2.0.0 notes with shipped phase work and current runtime behavior
- document avatar activity tracking and contrast inspector updates
- remove stale or inaccurate release wording around theme and preference scope
