### PR TITLE
chore(hardening): enforce official listing policy and remove avatar test seeding

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: marklearst
+buy_me_a_coffee: marklearst

--- a/.github/OFFICIAL_LISTING_POLICY.md
+++ b/.github/OFFICIAL_LISTING_POLICY.md
@@ -1,6 +1,7 @@
-# Official Listing and Attribution Guidance
+# Official Listing Policy
 
-This project is open source and community-friendly. To help users get the safest and most up-to-date experience, please point people to the official a11y Companion Widget listing and repository when sharing the widget.
+This repository is maintained for the official A11Y Companion widget release.
+When sharing this widget, use only the official listing and repository links below.
 
 ## Official Sources
 
@@ -9,17 +10,17 @@ This project is open source and community-friendly. To help users get the safest
 - Official GitHub repository and releases:
   - https://github.com/marklearst/a11y-companion-widget
 
-## Project Request
+## Policy
 
-- Please do not publish rebranded or near-identical copies of this widget to Figma Community.
-- Please do not republish this widget under a different name, branding, or listing.
+- Do not publish rebranded or near-identical copies of this widget to Figma Community.
+- Do not republish this widget under a different name, branding, or listing.
 - Do not create alternate public listings of this widget (or substantially similar copies) in Figma Community.
 - The official listing is the only supported public release from this project.
 
 ## Why This Matters
 
 - Users get timely fixes and accurate release notes from the official source.
-- Community trust improves when attribution is clear.
+- Users avoid confusion when only one official source is used.
 - Unofficial copies can include unreviewed changes, regressions, or security issues that this project cannot support.
 
 ## If You Find a Confusing Re-Listing

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you find a security issue, please do not open a public issue.
+
+- Preferred: open a private GitHub security advisory for this repository.
+- If advisories are unavailable, open a regular issue with the title prefix `[SECURITY]` and share only high-level details first.
+
+## What to Include
+
+- Affected version(s)
+- Reproduction steps
+- Impact summary
+- Suggested fix (if available)
+
+## Response Targets
+
+- Initial acknowledgment: within 72 hours
+- Follow-up status: within 7 days

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -5,7 +5,7 @@
 If you find a security issue, please do not open a public issue.
 
 - Preferred: open a private GitHub security advisory for this repository.
-- If advisories are unavailable, open a regular issue with the title prefix `[SECURITY]` and share only high-level details first.
+- If advisories are unavailable, open a regular issue with the title prefix `[SECURITY]` and include no technical or exploit details; maintainers will move follow-up to a private channel.
 
 ## What to Include
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,29 @@
+# Support
+
+Thanks for using A11Y Companion.
+
+## Get Help
+
+- For bugs and regressions, open an issue:
+  - https://github.com/marklearst/a11y-companion-widget/issues
+- For security concerns, use the security policy:
+  - `./SECURITY.md`
+
+## Issue Reporting Checklist
+
+Please include:
+
+- Figma or FigJam context
+- Reproduction steps
+- Expected behavior and actual behavior
+- Screenshot or short screen recording
+- Environment details (OS + Figma desktop/web version)
+
+## Response Expectations
+
+Support is maintainer-led and best-effort. Priority is given to:
+
+1. Reproducible bugs
+2. Security-impacting issues
+3. Regressions from recent releases
+

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ assets
 !AGENTS.md
 !CHANGELOG.md
 !ANALYSIS-REPORT.md
+!THIRD_PARTY_NOTICES.md
+!.github/OFFICIAL_LISTING_POLICY.md
+!.github/SECURITY.md
+!.github/SUPPORT.md
 DESIGN_SYSTEM_*.md
 
 # production

--- a/ANALYSIS-REPORT.md
+++ b/ANALYSIS-REPORT.md
@@ -171,14 +171,14 @@ The **A11Y Companion Widget** is a **high-quality, well-architected Figma widget
 
 **Minor gaps:**
 - No architecture decision records (ADRs)
-- No contributing guide (CONTRIBUTING.md)
+- No maintainer workflow doc
 - No issue templates
-- No PR template
+- No internal review checklist template
 - Design system could use visual documentation
 
 **Recommendations:**
-- Add CONTRIBUTING.md for new contributors
-- Add GitHub issue/PR templates
+- Add maintainer workflow documentation
+- Add GitHub issue and internal review checklist templates
 - Consider Storybook-style docs for design system
 - Add ADRs for major architectural decisions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Phase 2 - Contrast Hardening**
   - Runtime accent-step policy for contrast-safe theme resolution in light/dark modes.
   - Expanded hardening checks for contrast policy, preset matching, and shared utility behavior.
+- **Phase 3 - Deprecation Cleanup**
+  - Canonical variable imports were standardized across runtime modules.
+  - Legacy primitive variable aliases and deprecated theme options were removed (see **Removed** for details).
 - **Phase 4 - Widget UX Upgrades**
   - Widget contrast inspector with on-canvas preview and property-menu toggle.
   - Unsupported-selection diagnostics for:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Mark Learst
+Copyright (c) 2025-2026 Mark Learst
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2025-2026 Mark Learst
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025-2026 Mark Learst
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Built and maintained by Mark Learst.
 ![GitHub issues](https://img.shields.io/github/issues/marklearst/a11y-companion-widget?style=flat-square)
 [![Figma Community](https://img.shields.io/badge/Figma%20Widget-Open%20in%20Figma-blue?style=flat-square&logo=figma)](https://www.figma.com/community/widget/1509302611418259130)
 
-A modern, open-source Figma widget that brings the [A11Y Project Checklist](https://www.a11yproject.com/checklist/) directly into your design workflow. Use this widget to check your designs, content, and code for accessibility and WCAG compliance, collaboratively with your team.
+A production Figma widget that brings the [A11Y Project Checklist](https://www.a11yproject.com/checklist/) directly into your design workflow. Use this widget to check your designs, content, and code for accessibility and WCAG compliance with your team.
 
 [a11y Companion Widget | Figma Community](https://www.figma.com/community/widget/1509302611418259130)
 
@@ -90,9 +90,16 @@ Based on the authoritative [A11Y Project Checklist](https://www.a11yproject.com/
 
 The inspector supports solid and single-gradient scenarios. Unsupported combinations are reported with explicit status messages.
 
-## ⚙️ For Builders
+## ⚠️ Distribution Guardrails
 
-Key local commands:
+This repository exists to maintain the official A11Y Companion widget.
+Do not publish forks, clones, or modified builds to Figma Community.
+Use the official listing linked above.
+If you need changes, open an issue please.
+
+## 🔒 Internal Maintenance Checks (Official Listing)
+
+Checks used for maintaining the official repository and release workflow:
 
 - `pnpm run build` - bundle widget code to `dist/code.js`
 - `pnpm run watch` - rebuild on file changes
@@ -131,16 +138,17 @@ For security-related reports, use the repository security policy:
 
 - [Support](.github/SUPPORT.md)
 - [Third-Party Notices](THIRD_PARTY_NOTICES.md)
-- [Listing and Attribution Guidance](.github/LISTING_ATTRIBUTION_GUIDANCE.md)
+- [Official Listing Policy](.github/OFFICIAL_LISTING_POLICY.md)
 
-This project is open source. Please use the official widget listing/repository for the safest and most up-to-date version. Unofficial copies may include unreviewed changes, security issues, or regressions and are not supported by this project.
+This repository is maintained for the official widget release.
+Use only the official listing/repository for the safest and most up-to-date version. Unofficial copies may include unreviewed changes, security issues, or regressions and are not supported by this project.
 Please do not republish this widget under a different name or listing in Figma Community.
 
 ## 🤔 Why use this widget?
 
 - Ensure your designs and content meet accessibility standards
 - Make accessibility a collaborative, visible part of your workflow
-- Reference the latest, community-driven accessibility guidance
+- Reference the latest accessibility guidance from trusted sources
 
 ## 🙌 Credits
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Based on the authoritative [A11Y Project Checklist](https://www.a11yproject.com/
 6. Click the **collapse/expand** button (▲/▼) to quickly navigate sections.
 7. Hover over checklist items for WCAG references and detailed explanations.
 8. Use the **property menu** to:
-   - Change language (English/Espanol)
+   - Change language (English/Español)
    - Change checklist template
    - Switch between light/dark themes
    - Switch accent color themes (Default, Indigo, Emerald, Rose, Slate, Cyan)
@@ -95,7 +95,7 @@ The inspector supports solid and single-gradient scenarios. Unsupported combinat
 This repository exists to maintain the official A11Y Companion widget.
 Do not publish forks, clones, or modified builds to Figma Community.
 Use the official listing linked above.
-If you need changes, open an issue please.
+If you need changes, please open an issue.
 
 ## 🔒 Internal Maintenance Checks (Official Listing)
 
@@ -161,5 +161,5 @@ Please do not republish this widget under a different name or listing in Figma C
 
 ## 📝 License
 
-This project is licensed under the [MIT License](LICENSE).
+This project is licensed under the [Apache License 2.0](LICENSE).
 © 2025–2026 Mark Learst

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,13 @@
+# Third-Party Notices
+
+This project includes and adapts checklist data from The A11Y Project.
+
+## The A11Y Project Checklist Data
+
+- Upstream project: https://github.com/a11yproject/a11yproject.com
+- Checklist reference: https://www.a11yproject.com/checklist/
+- License: Apache License 2.0
+
+This repository uses adapted checklist data for widget integration and presentation in Figma/FigJam. Attribution and license references are preserved.
+
+If upstream licensing metadata changes, this notice should be updated accordingly.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -9,5 +9,6 @@ This project includes and adapts checklist data from The A11Y Project.
 - License: Apache License 2.0
 
 This repository uses adapted checklist data for widget integration and presentation in Figma/FigJam. Attribution and license references are preserved.
+A copy of the Apache License 2.0 text is available in `LICENSE`.
 
 If upstream licensing metadata changes, this notice should be updated accordingly.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pnpm": ">=10"
   },
   "author": "Mark Learst",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@figma/eslint-plugin-figma-plugins": "*",
     "@figma/plugin-typings": "*",

--- a/widget-src/hooks/useAvatarProfiles.ts
+++ b/widget-src/hooks/useAvatarProfiles.ts
@@ -1,7 +1,7 @@
 const { widget } = figma;
 const { useSyncedMap, useSyncedState, useEffect } = widget;
 
-import { defaultTheme, withOpacity } from "design-system/theme/default";
+import { withOpacity } from "design-system/theme/default";
 import { capAvatarIds } from "shared/avatarStack";
 
 type AvatarProfile = {
@@ -71,26 +71,7 @@ const resolveUserId = (
   return null;
 };
 
-const ENABLE_TEST_AVATARS = true;
-const TEST_AVATAR_NAMES = [
-  "Ava Test",
-  "Lee Sample",
-  "Kai Demo",
-  "Riley QA",
-  "Morgan UX",
-  "Jordan Dev",
-  "Taylor Ops",
-  "Casey PM",
-  "Sam Review",
-  "Alex Design",
-];
-const TEST_AVATAR_COLORS = [
-  defaultTheme.brand.purple[100],
-  defaultTheme.neutral.gray[100],
-  defaultTheme.semantic.success.light,
-  defaultTheme.semantic.warning.light,
-  defaultTheme.neutral.gray[900],
-];
+const TEST_AVATAR_ID_PATTERN = /^test:\d+$/;
 
 export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
   const { accentColor, neutralDark, neutralLight, max = 5 } = options;
@@ -98,10 +79,6 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
   const [avatarIds, setAvatarIds] = useSyncedState<string[]>(
     "avatarIds",
     []
-  );
-  const [seeded, setSeeded] = useSyncedState<boolean>(
-    "avatarTestSeeded",
-    false
   );
   const visibleAvatarIds = capAvatarIds(avatarIds, max);
 
@@ -143,35 +120,19 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
   };
 
   useEffect(() => {
-    if (!ENABLE_TEST_AVATARS) return;
-    const hasAllTestAvatarIds = TEST_AVATAR_NAMES.every((_, index) =>
-      avatarIds.includes(`test:${index + 1}`)
-    );
-    if (seeded && hasAllTestAvatarIds) return;
-    const nextIds = [...avatarIds];
-    TEST_AVATAR_NAMES.forEach((name, index) => {
-      const id = `test:${index + 1}`;
-      const existing = avatarProfiles.get(id);
-      if (!existing) {
-        avatarProfiles.set(id, {
-          id,
-          name,
-          initials: getInitials(name),
-          photoUrl: null,
-          color: TEST_AVATAR_COLORS[index % TEST_AVATAR_COLORS.length],
-          sessionId: null,
-        });
-      }
-      if (!nextIds.includes(id)) {
-        nextIds.push(id);
-      }
-    });
+    const testIds = avatarIds.filter((id) => TEST_AVATAR_ID_PATTERN.test(id));
+    if (testIds.length === 0) {
+      return;
+    }
+    const nextIds = avatarIds.filter((id) => !TEST_AVATAR_ID_PATTERN.test(id));
     if (nextIds.join("|") !== avatarIds.join("|")) {
       setAvatarIds(nextIds);
     }
-    if (!seeded) {
-      setSeeded(true);
-    }
+    testIds.forEach((id) => {
+      if (avatarProfiles.get(id)) {
+        avatarProfiles.delete(id);
+      }
+    });
   });
 
   const profiles = visibleAvatarIds

--- a/widget-src/hooks/useAvatarProfiles.ts
+++ b/widget-src/hooks/useAvatarProfiles.ts
@@ -119,6 +119,7 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
     });
   };
 
+  // Figma Widget useEffect does not support a dependency array.
   useEffect(() => {
     const testIds = avatarIds.filter((id) => TEST_AVATAR_ID_PATTERN.test(id));
     if (testIds.length === 0) {


### PR DESCRIPTION
- replace listing attribution guidance with an official listing policy

- harden README and support docs toward issue-only maintainer workflow

- remove avatar test seeding path and auto-clean stale test avatar records

- include security/support/funding/legal metadata files in the release set
