### PR TITLE
chore/official listing hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Built and maintained by Mark Learst.
 
-| Signal | Status |
+| Project Health | Status |
 | --- | --- |
 | License | ![License](https://img.shields.io/github/license/marklearst/a11y-companion-widget?style=flat-square) |
 | Latest release | ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/marklearst/a11y-companion-widget?sort=semver&style=flat-square) |

--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 Built and maintained by Mark Learst.
 
-![License](https://img.shields.io/github/license/marklearst/a11y-companion-widget?style=flat-square)
-![GitHub last commit](https://img.shields.io/github/last-commit/marklearst/a11y-companion-widget?style=flat-square)
-![GitHub issues](https://img.shields.io/github/issues/marklearst/a11y-companion-widget?style=flat-square)
+| Signal | Status |
+| --- | --- |
+| License | ![License](https://img.shields.io/github/license/marklearst/a11y-companion-widget?style=flat-square) |
+| Latest release | ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/marklearst/a11y-companion-widget?sort=semver&style=flat-square) |
+| Last commit | ![GitHub last commit](https://img.shields.io/github/last-commit/marklearst/a11y-companion-widget?style=flat-square) |
+| Commit activity | ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/marklearst/a11y-companion-widget?style=flat-square) |
+| Open issues | ![GitHub issues](https://img.shields.io/github/issues/marklearst/a11y-companion-widget?style=flat-square) |
+| Closed issues | ![GitHub closed issues](https://img.shields.io/github/issues-closed/marklearst/a11y-companion-widget?style=flat-square) |
+| Contributors | ![GitHub contributors](https://img.shields.io/github/contributors/marklearst/a11y-companion-widget?style=flat-square) |
+| Tooling | ![pnpm >=10](https://img.shields.io/badge/pnpm-%3E%3D10-F69220?style=flat-square&logo=pnpm&logoColor=white) |
+
 [![Figma Community](https://img.shields.io/badge/Figma%20Widget-Open%20in%20Figma-blue?style=flat-square&logo=figma)](https://www.figma.com/community/widget/1509302611418259130)
 
 A production Figma widget that brings the [A11Y Project Checklist](https://www.a11yproject.com/checklist/) directly into your design workflow. Use this widget to check your designs, content, and code for accessibility and WCAG compliance with your team.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Built and maintained by Mark Learst.
 | Open issues | ![GitHub issues](https://img.shields.io/github/issues/marklearst/a11y-companion-widget?style=flat-square) |
 | Closed issues | ![GitHub closed issues](https://img.shields.io/github/issues-closed/marklearst/a11y-companion-widget?style=flat-square) |
 | Contributors | ![GitHub contributors](https://img.shields.io/github/contributors/marklearst/a11y-companion-widget?style=flat-square) |
+| Platform | ![Figma Widget API](https://img.shields.io/badge/platform-Figma%20Widget%20API-0ACF83?style=flat-square&logo=figma&logoColor=white) |
 | Tooling | ![pnpm >=10](https://img.shields.io/badge/pnpm-%3E%3D10-F69220?style=flat-square&logo=pnpm&logoColor=white) |
 
 [![Figma Community](https://img.shields.io/badge/Figma%20Widget-Open%20in%20Figma-blue?style=flat-square&logo=figma)](https://www.figma.com/community/widget/1509302611418259130)

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Built and maintained by Mark Learst.
 | Contributors | ![GitHub contributors](https://img.shields.io/github/contributors/marklearst/a11y-companion-widget?style=flat-square) |
 | Platform | ![Figma Widget API](https://img.shields.io/badge/platform-Figma%20Widget%20API-0ACF83?style=flat-square&logo=figma&logoColor=white) |
 | Tooling | ![pnpm >=10](https://img.shields.io/badge/pnpm-%3E%3D10-F69220?style=flat-square&logo=pnpm&logoColor=white) |
-
-[![Figma Community](https://img.shields.io/badge/Figma%20Widget-Open%20in%20Figma-blue?style=flat-square&logo=figma)](https://www.figma.com/community/widget/1509302611418259130)
+| Figma Community | [![Figma Widget](https://img.shields.io/badge/Figma%20Widget-Open%20in%20Figma-blue?style=flat-square&logo=figma)](https://www.figma.com/community/widget/1509302611418259130) |
 
 A production Figma widget that brings the [A11Y Project Checklist](https://www.a11yproject.com/checklist/) directly into your design workflow. Use this widget to check your designs, content, and code for accessibility and WCAG compliance with your team.
 


### PR DESCRIPTION
- **docs(readme): add curated project health badge table**
- **docs(readme): rename badge table header to project health**
- **docs(readme): add figma widget api platform badge**
- **docs(readme): move figma community badge into health table**
