### PR TITLE
fix(sync): sanitize eleventy templates and preserve wcag levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ Built and maintained by Mark Learst.
 | Commit activity | ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/marklearst/a11y-companion-widget?style=flat-square) |
 | Open issues | ![GitHub issues](https://img.shields.io/github/issues/marklearst/a11y-companion-widget?style=flat-square) |
 | Closed issues | ![GitHub closed issues](https://img.shields.io/github/issues-closed/marklearst/a11y-companion-widget?style=flat-square) |
-| Contributors | ![GitHub contributors](https://img.shields.io/github/contributors/marklearst/a11y-companion-widget?style=flat-square) |
 | Platform | ![Figma Widget API](https://img.shields.io/badge/platform-Figma%20Widget%20API-0ACF83?style=flat-square&logo=figma&logoColor=white) |
 | Tooling | ![pnpm >=10](https://img.shields.io/badge/pnpm-%3E%3D10-F69220?style=flat-square&logo=pnpm&logoColor=white) |
 | Figma Community | [![Figma Widget](https://img.shields.io/badge/Figma%20Widget-Open%20in%20Figma-blue?style=flat-square&logo=figma)](https://www.figma.com/community/widget/1509302611418259130) |
 
-A production Figma widget that brings the [A11Y Project Checklist](https://www.a11yproject.com/checklist/) directly into your design workflow. Use this widget to check your designs, content, and code for accessibility and WCAG compliance with your team.
+A11Y Companion is the official accessibility checklist widget for Figma and FigJam, built and maintained by Mark Learst. It brings the [A11Y Project Checklist](https://www.a11yproject.com/checklist/) directly into your workflow for manual, team-visible WCAG tracking, with clear guidance and progress.
 
 [a11y Companion Widget | Figma Community](https://www.figma.com/community/widget/1509302611418259130)
 
@@ -100,10 +99,9 @@ The inspector supports solid and single-gradient scenarios. Unsupported combinat
 
 ## ⚠️ Distribution Guardrails
 
-This repository exists to maintain the official A11Y Companion widget.
-Do not publish forks, clones, or modified builds to Figma Community.
-Use the official listing linked above.
-If you need changes, please open an issue.
+This repository maintains the official A11Y Companion widget listing.
+Please do not publish forks, clones, or modified builds to Figma Community.
+Use the official listing linked above. For changes or requests, open an issue.
 
 ## 🔒 Internal Maintenance Checks (Official Listing)
 
@@ -124,7 +122,7 @@ Public roadmap updates are published with release notes in [`CHANGELOG.md`](CHAN
 
 ## 🐞 Report Issues
 
-Found a bug or regression? Open an issue here:
+Found a bug or regression in the official widget? Open an issue here:
 
 - [GitHub Issues](https://github.com/marklearst/a11y-companion-widget/issues)
 
@@ -152,20 +150,14 @@ This repository is maintained for the official widget release.
 Use only the official listing/repository for the safest and most up-to-date version. Unofficial copies may include unreviewed changes, security issues, or regressions and are not supported by this project.
 Please do not republish this widget under a different name or listing in Figma Community.
 
-## 🤔 Why use this widget?
-
-- Ensure your designs and content meet accessibility standards
-- Make accessibility a collaborative, visible part of your workflow
-- Reference the latest accessibility guidance from trusted sources
-
 ## 🙌 Credits
 
 - Checklist data and guidance from [The A11Y Project](https://www.a11yproject.com/checklist/)
 - Widget built with the [Figma Widget API](https://www.figma.com/widget-docs/api/api-reference/)
 
-## 🚀 Make Accessibility First-Class
+## 💬 Personal Message
 
-**Make accessibility a first-class part of your design and development process!**
+Accessibility is personal for me. I have been the eyes and ears for my legally blind and deaf brother for decades, and I have seen how often the web shuts him out. That loss of access is not theoretical. It is hours of digging through sites that do not care. I do not share this for vibes. I share it because it is the reason I built this, and why I will keep caring about getting it right. My brother is my biggest inspiration.
 
 ## 📝 License
 

--- a/scripts/sync-a11y-checklist.mjs
+++ b/scripts/sync-a11y-checklist.mjs
@@ -8,6 +8,10 @@ import { spawnSync } from "node:child_process";
 
 const SOURCE_URL =
   "https://raw.githubusercontent.com/a11yproject/a11yproject.com/main/src/_data/checklists.json";
+const FAIL_ON_UNRESOLVED_TEMPLATES = false;
+const ELEVENTY_URL_TEMPLATE_REGEX =
+  /\{\{\s*(['"])(.*?)\1\s*\|\s*url\s*\}\}/g;
+const WCAG_LEVELS = new Set(["A", "AA", "AAA"]);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -45,10 +49,212 @@ async function fetchText(url) {
   });
 }
 
+function formatPath(pathParts) {
+  if (!pathParts.length) return "<root>";
+  let output = "";
+  for (const part of pathParts) {
+    if (part.startsWith("[")) {
+      output += part;
+    } else {
+      output += output ? `.${part}` : part;
+    }
+  }
+  return output;
+}
+
+function sanitizeTemplateString(value) {
+  let replacementCount = 0;
+  const sanitized = value.replace(
+    ELEVENTY_URL_TEMPLATE_REGEX,
+    (_match, _quote, pathValue) => {
+      replacementCount += 1;
+      return String(pathValue ?? "").trim();
+    },
+  );
+  return { sanitized, replacementCount };
+}
+
+function hasTemplateMarkers(value) {
+  return value.includes("{{") || value.includes("}}");
+}
+
+function normalizeLevel(value) {
+  if (!value) return null;
+  const normalized = String(value).trim().toUpperCase();
+  return WCAG_LEVELS.has(normalized) ? normalized : null;
+}
+
+function parseWcagCode(value) {
+  const match = String(value ?? "").match(/(\d+\.\d+\.\d+)/);
+  return match ? match[1] : null;
+}
+
+async function readJsonIfExists(filePath) {
+  try {
+    const content = await fs.readFile(filePath, "utf8");
+    return JSON.parse(content);
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function buildLevelLookup(existingChecklist) {
+  const byCheckboxId = new Map();
+  const byCode = new Map();
+  if (!existingChecklist || typeof existingChecklist !== "object") {
+    return { byCheckboxId, byCode };
+  }
+
+  for (const sectionData of Object.values(existingChecklist)) {
+    const tasks = Array.isArray(sectionData?.tasks) ? sectionData.tasks : [];
+    for (const task of tasks) {
+      const level = normalizeLevel(task?.level);
+      if (!level) continue;
+
+      const checkboxId = String(task?.checkboxId ?? "").trim();
+      if (checkboxId && !byCheckboxId.has(checkboxId)) {
+        byCheckboxId.set(checkboxId, level);
+      }
+
+      const code = parseWcagCode(task?.wcag);
+      if (code && !byCode.has(code)) {
+        byCode.set(code, level);
+      }
+    }
+  }
+
+  return { byCheckboxId, byCode };
+}
+
+function hydrateTaskLevels(checklistData, levelLookup) {
+  const report = {
+    hydratedCount: 0,
+    unresolvedPaths: [],
+  };
+
+  if (!checklistData || typeof checklistData !== "object") {
+    return { hydrated: checklistData, report };
+  }
+
+  for (const [sectionKey, sectionData] of Object.entries(checklistData)) {
+    const tasks = Array.isArray(sectionData?.tasks) ? sectionData.tasks : [];
+    tasks.forEach((task, index) => {
+      const existingLevel = normalizeLevel(task?.level);
+      if (existingLevel) {
+        task.level = existingLevel;
+        return;
+      }
+
+      const checkboxId = String(task?.checkboxId ?? "").trim();
+      const wcagCode = parseWcagCode(task?.wcag);
+      const hydratedLevel =
+        (checkboxId ? levelLookup.byCheckboxId.get(checkboxId) : undefined) ??
+        (wcagCode ? levelLookup.byCode.get(wcagCode) : undefined) ??
+        null;
+
+      if (hydratedLevel) {
+        task.level = hydratedLevel;
+        report.hydratedCount += 1;
+        return;
+      }
+
+      if (wcagCode) {
+        report.unresolvedPaths.push(`${sectionKey}.tasks[${index}]`);
+      }
+    });
+  }
+
+  return { hydrated: checklistData, report };
+}
+
+function logLevelHydrationReport(report) {
+  if (report.hydratedCount > 0) {
+    console.warn(
+      `[sync:a11y-checklist] Hydrated WCAG level on ${report.hydratedCount} task(s) using existing checklist data.`,
+    );
+  }
+
+  if (report.unresolvedPaths.length > 0) {
+    console.warn(
+      `[sync:a11y-checklist] Missing WCAG level on ${report.unresolvedPaths.length} task(s) after hydration:\n- ${report.unresolvedPaths.join("\n- ")}`,
+    );
+  }
+}
+
+function sanitizeTemplatesDeep(input) {
+  const report = {
+    replacementCount: 0,
+    transformedPaths: [],
+    unresolvedPaths: [],
+  };
+
+  const walk = (value, pathParts) => {
+    if (typeof value === "string") {
+      const { sanitized, replacementCount } = sanitizeTemplateString(value);
+      if (replacementCount > 0) {
+        report.replacementCount += replacementCount;
+        report.transformedPaths.push(formatPath(pathParts));
+      }
+      if (hasTemplateMarkers(sanitized)) {
+        report.unresolvedPaths.push(formatPath(pathParts));
+      }
+      return sanitized;
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((entry, index) => walk(entry, [...pathParts, `[${index}]`]));
+    }
+
+    if (value && typeof value === "object") {
+      const result = {};
+      for (const [key, entry] of Object.entries(value)) {
+        result[key] = walk(entry, [...pathParts, key]);
+      }
+      return result;
+    }
+
+    return value;
+  };
+
+  const sanitized = walk(input, []);
+  return { sanitized, report };
+}
+
+function logTemplateSanitizerReport(report) {
+  if (report.replacementCount > 0) {
+    console.warn(
+      `[sync:a11y-checklist] Sanitized ${report.replacementCount} Eleventy URL template expression(s) across ${report.transformedPaths.length} field(s).`,
+    );
+    console.warn(
+      `[sync:a11y-checklist] Sanitized field paths:\n- ${report.transformedPaths.join("\n- ")}`,
+    );
+  }
+
+  if (report.unresolvedPaths.length > 0) {
+    const summary = `[sync:a11y-checklist] Found ${report.unresolvedPaths.length} field(s) with unresolved template markers after sanitization:\n- ${report.unresolvedPaths.join("\n- ")}`;
+    if (FAIL_ON_UNRESOLVED_TEMPLATES) {
+      throw new Error(summary);
+    }
+    console.warn(summary);
+  }
+}
+
 async function main() {
   const raw = await fetchText(SOURCE_URL);
   const parsed = JSON.parse(raw);
-  const pretty = `${JSON.stringify(parsed, null, 2)}\n`;
+  const existingChecklist = await readJsonIfExists(OUTPUT_PATH);
+  const levelLookup = buildLevelLookup(existingChecklist);
+  const { sanitized, report } = sanitizeTemplatesDeep(parsed);
+  const { hydrated, report: levelReport } = hydrateTaskLevels(
+    sanitized,
+    levelLookup,
+  );
+  logTemplateSanitizerReport(report);
+  logLevelHydrationReport(levelReport);
+  const pretty = `${JSON.stringify(hydrated, null, 2)}\n`;
   await fs.mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
   await fs.writeFile(OUTPUT_PATH, pretty, "utf8");
   console.log(`Wrote ${OUTPUT_PATH}`);

--- a/widget-src/components/checklist/ChecklistSection.tsx
+++ b/widget-src/components/checklist/ChecklistSection.tsx
@@ -2,7 +2,7 @@ const { widget } = figma;
 const { AutoLayout, Text } = widget;
 
 import { ChecklistSectionProps } from "types/index";
-import { ProgressTracker } from "components/primitives";
+import { ProgressTracker, RichText } from "components/primitives";
 import { ChecklistItem } from "components/checklist";
 import { useChecklistSectionState } from "hooks/useChecklistSectionState";
 import CaretIcon from "components/checklist/CaretIcon";
@@ -214,17 +214,16 @@ function ChecklistSection({
           width="fill-parent"
           verticalAlignItems="center"
         >
-          <Text
-            name="SectionDescription"
+          <RichText
+            text={section.description}
+            inlineStyles={uiTokens.inline}
+            width="fill-parent"
             fill={palette.sectionDescText}
+            lineHeight={uiTokens.section.description.lineHeight}
             fontFamily={uiTokens.section.description.fontFamily}
             fontSize={uiTokens.section.description.fontSize}
             fontWeight={uiTokens.section.description.fontWeight}
-            lineHeight={uiTokens.section.description.lineHeight}
-            width="fill-parent"
-          >
-            {section.description}
-          </Text>
+          />
         </AutoLayout>
       ) : null}
       {visibleItems.map((item, index) => (

--- a/widget-src/data/checklist.json
+++ b/widget-src/data/checklist.json
@@ -37,7 +37,7 @@
         "wcag": "4.1.1 Parsing",
         "url": "https://www.w3.org/WAI/WCAG22/Understanding/parsing.html",
         "description": "<a href='https://validator.w3.org/nu/'>Valid HTML</a> helps to provide a consistent, expected experience across all browsers and assistive technology.",
-        "level": null
+        "level": "A"
       },
       {
         "title": "Use a <code>lang</code> attribute on the <code>html</code> element.",
@@ -305,8 +305,7 @@
         "checkboxId": "identify-new-window",
         "wcag": "G201: Giving users advanced warning when opening a new window",
         "url": "https://www.w3.org/WAI/WCAG22/Techniques/general/G201",
-        "description": "Ideally, avoid links that open in a new tab or window. If a link does, ensure the link's behavior will be communicated in a way that is apparent to all users. Doing this will help people understand what will happen before activating the link. While this technique is technically not required for compliance, it is an often-cited area of frustration for many different kinds of assistive technology users.",
-        "level": null
+        "description": "Ideally, avoid links that open in a new tab or window. If a link does, ensure the link's behavior will be communicated in a way that is apparent to all users. Doing this will help people understand what will happen before activating the link. While this technique is technically not required for compliance, it is an often-cited area of frustration for many different kinds of assistive technology users."
       }
     ]
   },
@@ -538,7 +537,7 @@
     ]
   },
   "color contrast": {
-    "preface": "<a href=\"{{ '/posts/what-is-color-contrast/' | url }}\">Color contrast</a> is how legible colors are when placed next to, and on top of each other.",
+    "preface": "<a href=\"/posts/what-is-color-contrast/\">Color contrast</a> is how legible colors are when placed next to, and on top of each other.",
     "tasks": [
       {
         "title": "Check the contrast for all normal-sized text.",

--- a/widget-src/data/wcagLevelMap.ts
+++ b/widget-src/data/wcagLevelMap.ts
@@ -110,7 +110,7 @@ export const wcagLevelCriteriaMap: WcagLevelCriteriaMap = {
     },
     {
       "code": "4.1.1",
-      "title": "Use the <code>th</code> element for table headers (with appropriate <code>scope</code> attributes).",
+      "title": "Validate your HTML.",
       "url": "https://www.w3.org/WAI/WCAG22/Understanding/parsing.html"
     },
     {

--- a/widget-src/design-system/components/checklist.ts
+++ b/widget-src/design-system/components/checklist.ts
@@ -231,10 +231,10 @@ const companionLayout: ChecklistLayoutVariables = {
     avatar: {
       size: dimensions.avatarMd,
       radius: borderRadius.full,
-      strokeWidth: borderWidth.base,
+      strokeWidth: borderWidth.thin,
       fontSize: fontSize.xs,
       fontWeight: fontWeight.bold,
-      stackOffsetX: -8,
+      stackOffsetX: -6,
       maxVisible: 4,
     },
   },

--- a/widget-src/hooks/useAvatarProfiles.ts
+++ b/widget-src/hooks/useAvatarProfiles.ts
@@ -1,7 +1,6 @@
 const { widget } = figma;
 const { useSyncedMap, useSyncedState, useEffect } = widget;
 
-import { withOpacity } from "design-system/theme/default";
 import { capAvatarIds } from "shared/avatarStack";
 
 type AvatarProfile = {
@@ -30,25 +29,64 @@ type UseAvatarProfilesOptions = {
   max?: number;
 };
 
-const normalizeHex = (hex: string) => {
+const normalizeHex = (hex: string): string | null => {
   const raw = hex.replace("#", "").trim();
-  if (raw.length === 3) {
+  if (raw.length === 3 && /^[0-9a-fA-F]{3}$/.test(raw)) {
     return raw
       .split("")
       .map((c) => `${c}${c}`)
       .join("");
   }
-  if (raw.length === 8) return raw.slice(0, 6);
-  return raw.padEnd(6, "0");
+  if (raw.length === 6 && /^[0-9a-fA-F]{6}$/.test(raw)) {
+    return raw;
+  }
+  if (raw.length === 8 && /^[0-9a-fA-F]{8}$/.test(raw)) {
+    return raw.slice(0, 6);
+  }
+  return null;
 };
 
 const isLightColor = (hex: string) => {
   const value = normalizeHex(hex);
+  if (!value) return false;
   const r = parseInt(value.slice(0, 2), 16);
   const g = parseInt(value.slice(2, 4), 16);
   const b = parseInt(value.slice(4, 6), 16);
   const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
   return luminance > 0.6;
+};
+
+const toOpaqueHex = (color: string | null | undefined): string | null => {
+  if (!color) return null;
+  const normalized = normalizeHex(color);
+  return normalized ? `#${normalized.toUpperCase()}` : null;
+};
+
+const FALLBACK_AVATAR_COLORS = [
+  "#4C6EF5",
+  "#0F766E",
+  "#C2410C",
+  "#7C3AED",
+  "#0369A1",
+  "#B45309",
+  "#BE123C",
+  "#15803D",
+];
+
+const hashString = (value: string) => {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+};
+
+const resolveFallbackAvatarColor = (id: string, accentColor: string) => {
+  const resolvedAccent = toOpaqueHex(accentColor);
+  const palette = resolvedAccent
+    ? [resolvedAccent, ...FALLBACK_AVATAR_COLORS]
+    : FALLBACK_AVATAR_COLORS;
+  return palette[hashString(id) % palette.length];
 };
 
 const getInitials = (name: string) => {
@@ -61,7 +99,7 @@ const getInitials = (name: string) => {
 const resolveUserId = (
   id: string | null,
   sessionId: number | null,
-  name: string
+  name: string,
 ) => {
   if (id) return id;
   if (sessionId !== null && sessionId !== undefined) {
@@ -72,15 +110,24 @@ const resolveUserId = (
 };
 
 const TEST_AVATAR_ID_PATTERN = /^test:\d+$/;
+const SHOW_DEBUG_TEST_AVATARS = false;
+const DEBUG_TEST_AVATARS = [
+  { id: "test:1", name: "Ava Test", color: "#4C6EF5" },
+  { id: "test:2", name: "Lee Sample", color: "#0F766E" },
+  { id: "test:3", name: "Kai Demo", color: "#C2410C" },
+  { id: "test:4", name: "Riley QA", color: "#7C3AED" },
+];
+const DEBUG_TEST_AVATAR_COLOR_BY_ID = DEBUG_TEST_AVATARS.reduce<
+  Record<string, string>
+>((acc, profile) => {
+  acc[profile.id] = profile.color;
+  return acc;
+}, {});
 
 export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
   const { accentColor, neutralDark, neutralLight, max = 5 } = options;
   const avatarProfiles = useSyncedMap<AvatarProfile>("avatarProfiles");
-  const [avatarIds, setAvatarIds] = useSyncedState<string[]>(
-    "avatarIds",
-    []
-  );
-  const visibleAvatarIds = capAvatarIds(avatarIds, max);
+  const [avatarIds, setAvatarIds] = useSyncedState<string[]>("avatarIds", []);
 
   const upsertAvatar = (profile: AvatarProfile) => {
     const existing = avatarProfiles.get(profile.id);
@@ -94,7 +141,10 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
     if (hasChanges) {
       avatarProfiles.set(profile.id, profile);
     }
-    const nextIds = [profile.id, ...avatarIds.filter((id) => id !== profile.id)];
+    const nextIds = [
+      profile.id,
+      ...avatarIds.filter((id) => id !== profile.id),
+    ];
     if (nextIds.join("|") !== avatarIds.join("|")) {
       setAvatarIds(nextIds);
     }
@@ -106,7 +156,7 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
     const resolvedId = resolveUserId(
       currentUser.id ?? null,
       currentUser.sessionId ?? null,
-      currentUser.name
+      currentUser.name,
     );
     if (!resolvedId) return;
     upsertAvatar({
@@ -121,6 +171,48 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
 
   // Figma Widget useEffect does not support a dependency array.
   useEffect(() => {
+    if (SHOW_DEBUG_TEST_AVATARS) {
+      const debugIds = DEBUG_TEST_AVATARS.map((profile) => profile.id);
+      DEBUG_TEST_AVATARS.forEach((profile) => {
+        const existing = avatarProfiles.get(profile.id);
+        const nextInitials = getInitials(profile.name);
+        const needsUpdate =
+          !existing ||
+          existing.name !== profile.name ||
+          existing.initials !== nextInitials ||
+          existing.photoUrl !== null ||
+          existing.sessionId !== null ||
+          existing.color !== profile.color;
+        if (needsUpdate) {
+          avatarProfiles.set(profile.id, {
+            id: profile.id,
+            name: profile.name,
+            initials: nextInitials,
+            photoUrl: null,
+            color: profile.color,
+            sessionId: null,
+          });
+        }
+      });
+      const currentUser = figma.currentUser;
+      const currentUserId =
+        currentUser &&
+        resolveUserId(
+          currentUser.id ?? null,
+          currentUser.sessionId ?? null,
+          currentUser.name,
+        );
+      // Keep the active real user first, then debug avatars for deterministic screenshots.
+      const nextIds = [
+        ...(currentUserId ? [currentUserId] : []),
+        ...debugIds.filter((id) => id !== currentUserId),
+      ];
+      if (nextIds.join("|") !== avatarIds.join("|")) {
+        setAvatarIds(nextIds);
+      }
+      return;
+    }
+
     const testIds = avatarIds.filter((id) => TEST_AVATAR_ID_PATTERN.test(id));
     if (testIds.length === 0) {
       return;
@@ -136,11 +228,15 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
     });
   });
 
+  const validAvatarIds = avatarIds.filter((id) =>
+    Boolean(avatarProfiles.get(id)),
+  );
+  const visibleAvatarIds = capAvatarIds(validAvatarIds, max);
   const profiles = visibleAvatarIds
     .map((id) => avatarProfiles.get(id))
     .filter((profile): profile is AvatarProfile => Boolean(profile));
-  const overflowCount = Math.max(0, avatarIds.length - profiles.length);
-  const overflowNames = avatarIds
+  const overflowCount = Math.max(0, validAvatarIds.length - profiles.length);
+  const overflowNames = validAvatarIds
     .slice(visibleAvatarIds.length)
     .map((id) => avatarProfiles.get(id)?.name?.trim() ?? "")
     .filter((name) => name.length > 0);
@@ -154,7 +250,14 @@ export function useAvatarProfiles(options: UseAvatarProfilesOptions) {
         src: profile.photoUrl,
       };
     }
-    const fill = profile.color ?? withOpacity(accentColor, 0.2);
+    const debugColor =
+      SHOW_DEBUG_TEST_AVATARS && TEST_AVATAR_ID_PATTERN.test(profile.id)
+        ? DEBUG_TEST_AVATAR_COLOR_BY_ID[profile.id]
+        : null;
+    const fill =
+      toOpaqueHex(debugColor) ??
+      toOpaqueHex(profile.color) ??
+      resolveFallbackAvatarColor(profile.id, accentColor);
     const textColor = isLightColor(fill) ? neutralDark : neutralLight;
     return {
       id: profile.id,

--- a/widget-src/hooks/useAvatarProfiles.ts
+++ b/widget-src/hooks/useAvatarProfiles.ts
@@ -1,6 +1,7 @@
 const { widget } = figma;
 const { useSyncedMap, useSyncedState, useEffect } = widget;
 
+import { brand, semantic } from "design-system/theme/default";
 import { capAvatarIds } from "shared/avatarStack";
 
 type AvatarProfile = {
@@ -63,14 +64,14 @@ const toOpaqueHex = (color: string | null | undefined): string | null => {
 };
 
 const FALLBACK_AVATAR_COLORS = [
-  "#4C6EF5",
-  "#0F766E",
-  "#C2410C",
-  "#7C3AED",
-  "#0369A1",
-  "#B45309",
-  "#BE123C",
-  "#15803D",
+  brand.accent.light,
+  semantic.success.dark,
+  semantic.warning.dark,
+  brand.accent.medium,
+  semantic.info.dark,
+  semantic.warning.medium,
+  semantic.error.dark,
+  semantic.success.medium,
 ];
 
 const hashString = (value: string) => {
@@ -112,10 +113,10 @@ const resolveUserId = (
 const TEST_AVATAR_ID_PATTERN = /^test:\d+$/;
 const SHOW_DEBUG_TEST_AVATARS = false;
 const DEBUG_TEST_AVATARS = [
-  { id: "test:1", name: "Ava Test", color: "#4C6EF5" },
-  { id: "test:2", name: "Lee Sample", color: "#0F766E" },
-  { id: "test:3", name: "Kai Demo", color: "#C2410C" },
-  { id: "test:4", name: "Riley QA", color: "#7C3AED" },
+  { id: "test:1", name: "Ava Test", color: brand.accent.light },
+  { id: "test:2", name: "Lee Sample", color: semantic.success.dark },
+  { id: "test:3", name: "Kai Demo", color: semantic.warning.dark },
+  { id: "test:4", name: "Riley QA", color: brand.accent.medium },
 ];
 const DEBUG_TEST_AVATAR_COLOR_BY_ID = DEBUG_TEST_AVATARS.reduce<
   Record<string, string>

--- a/widget-src/logic/checklistAdapter.ts
+++ b/widget-src/logic/checklistAdapter.ts
@@ -21,6 +21,14 @@ const normalizeKey = (value?: string) => {
   return value.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
 };
 
+const hasTemplateSyntax = (value?: string) => {
+  if (!value) return false;
+  const lowered = value.toLowerCase();
+  return (
+    lowered.includes("{{") || lowered.includes("}}") || lowered.includes("| url")
+  );
+};
+
 const resolveLegacySection = (
   legacy: LegacyChecklist,
   sectionId: string,
@@ -77,7 +85,9 @@ export function applyLegacyOverrides(
       });
       return {
         ...section,
-        description: legacySection.preface ?? section.description,
+        description: hasTemplateSyntax(legacySection.preface)
+          ? section.description
+          : legacySection.preface ?? section.description,
         items: tasks,
       };
     }),


### PR DESCRIPTION
- sanitize Eleventy url template expressions during checklist sync

- log transformed paths and unresolved template markers for QA visibility

- rehydrate missing task levels from existing checklist data to keep WCAG map generation stable

- guard legacy preface overrides when template syntax is detected at runtime

- sync regenerated checklist/map artifacts with sanitized color contrast preface
