### PR TITLE
fix(ui): prevent WCAG badge links from opening two tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-03-09
+
+### Fixed
+
+- Fixed WCAG badge links opening two tabs: removed duplicate `onClick` from inner `Text` that caused event bubbling to trigger `figma.openExternal` twice.
+
 ## [2.0.0] - 2026-02-12
 
 ### Added
@@ -64,12 +70,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `primitiveComponentVariables`
   - `primitiveComponentTokens`
 - Runtime `system` theme option from widget preferences and property-menu theme controls.
-
-## [2.0.1] - 2026-03-09
-
-### Fixed
-
-- Fixed WCAG badge links opening two tabs: removed duplicate `onClick` from inner `Text` that caused event bubbling to trigger `figma.openExternal` twice.
 
 ## [1.2.1] - 2025-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `primitiveComponentTokens`
 - Runtime `system` theme option from widget preferences and property-menu theme controls.
 
+## [2.0.1] - 2026-03-09
+
+### Fixed
+
+- Fixed WCAG badge links opening two tabs: removed duplicate `onClick` from inner `Text` that caused event bubbling to trigger `figma.openExternal` twice.
+
 ## [1.2.1] - 2025-12-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a11y-companion-widget",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "a11y Companion Widget",
   "scripts": {
     "build": "esbuild widget-src/code.tsx --bundle --outfile=dist/code.js --target=es6",

--- a/widget-src/components/checklist/WcagBadge.tsx
+++ b/widget-src/components/checklist/WcagBadge.tsx
@@ -85,7 +85,6 @@ export function WcagBadge({
           letterSpacing={badgeVariables.letterSpacing}
           textDecoration="none"
           hoverStyle={wcagUrl ? { fill: hoverTextColor } : undefined}
-          onClick={wcagUrl ? () => figma.openExternal(wcagUrl) : undefined}
         >
           {badgeLabel}
         </Text>


### PR DESCRIPTION
Root cause: Both the outer AutoLayout and inner Text had the same onClick
handler. A single click triggered both via event bubbling, causing
figma.openExternal to run twice.

Fix: Remove duplicate onClick from the Text element. The outer AutoLayout
retains the handler so the full badge (icon + text) remains clickable.

Verification:
- pnpm run build
- pnpm run lint
- pnpm run tsc
